### PR TITLE
Set TextSensor item type to String

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/TextSensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/TextSensorMessageHandler.java
@@ -41,7 +41,7 @@ public class TextSensorMessageHandler
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
-                .withConfiguration(configuration).build();
+                .withAcceptedItemType(channelType.getItemType()).withConfiguration(configuration).build();
 
         super.registerChannel(channel, channelType);
     }


### PR DESCRIPTION
When adding a TextSensor on the UI, it defaulted to Switch. 
This makes it default to String.