### PR TITLE
Fix item type for duration and signal_strength

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/SensorDeviceClass.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/SensorDeviceClass.java
@@ -16,7 +16,7 @@ public enum SensorDeviceClass {
     DATA_RATE("data_rate", "Number:DataTransferRate", null, null),
     DATA_SIZE("data_size", "Number:DataAmount", null, null),
     DISTANCE("distance", "Number:Length", null, null),
-    DURATION("duration", "Time", null, null),
+    DURATION("duration", "Number:Time", null, null),
     ENERGY("energy", "Number:Energy", "energy", "Energy"),
     ENERGY_STORAGE("energy_storage", "Number:Energy", "energy", "Energy"),
     FREQUENCY("frequency", "Number:Frequency", null, "Frequency"),
@@ -42,7 +42,7 @@ public enum SensorDeviceClass {
     PRECIPITATION_RATE("precipitation_rate", "Number:Speed", "rain", "Rain"),
     PRESSURE("pressure", "Number:Pressure", "pressure", "Pressure"),
     REACTIVE_POWER("reactive_power", "Number:Power", "energy", "Power"),
-    SIGNAL_STRENGTH("signal_strength", "Number:Dimensionless", "qualityofservice", null),
+    SIGNAL_STRENGTH("signal_strength", "Number:Power", "qualityofservice", null),
 
     SOUND_PRESSURE("sound_pressure", "Number:Dimensionless", "soundvolume", "SoundVolume"),
     SPEED("speed", "Number:Speed", "motion", null),


### PR DESCRIPTION
I'm not 100% sure on the signal_strength yet. 

I have this in my esphome config, essentially two different signal_strength:
```
sensor:
  - platform: wifi_signal
    id: wifi_signal_db
    name: RSSI
    update_interval: 300s
  - platform: copy # Reports the WiFi signal strength in %
    source_id: wifi_signal_db
    name: Signal
    filters:
      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
    unit_of_measurement: "%"
```

The first one, `RSSI`, has a unit of `dBm` by default, so the equivalent openHAB type should be `Number:Power`.

The second one, I overrode the unit to "%" but since it's still a `signal_strength`, a warning got issued by the binding because the type from Unit `Number:Dimensionless` doesn't match the new default here.

So maybe we should change the log from WARN to DEBUG?