### PR TITLE
Don't reconnect after having been disposed

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/handler/ESPHomeHandler.java
@@ -179,7 +179,9 @@ public class ESPHomeHandler extends BaseThingHandler implements PacketListener {
         } catch (ProtocolException e) {
             logger.warn("[{}] Error initial connection", config.hostname, e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
-            reconnectFuture = scheduler.schedule(this::connect, CONNECT_TIMEOUT * 2L, TimeUnit.SECONDS);
+            if (reconnectFuture != null) { // Don't reconnect if we've been disposed
+                reconnectFuture = scheduler.schedule(this::connect, CONNECT_TIMEOUT * 2L, TimeUnit.SECONDS);
+            }
         }
     }
 
@@ -187,6 +189,7 @@ public class ESPHomeHandler extends BaseThingHandler implements PacketListener {
     public void dispose() {
         if (reconnectFuture != null) {
             reconnectFuture.cancel(true);
+            reconnectFuture = null;
         }
         if (connection != null) {
             if (pingWatchdog != null) {


### PR DESCRIPTION
When an esp device is offline, the binding kept trying to reconnect even after the binding has been stopped.