### PR TITLE
Feat(ESPHome binding): Enhance binary sensor handling

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorDeviceClass.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorDeviceClass.java
@@ -1,0 +1,137 @@
+package no.seime.openhab.binding.esphome.internal.internal.message;
+
+/* Coded with the help of ChatGPT
+ * TODO: Should the type class also be dynamic (OpenClosed / OnOff / UpDown (org.openhab.core.library.types.UpDownType))
+ */
+public enum BinarySensorDeviceClass {
+    // Generic binary sensor with no specific context. 0: Off, 1: On.
+    GENERIC("generic", "Switch", "None", null),
+
+    // Indicates low battery status. 0: Battery not low, 1: Battery low.
+    BATTERY("battery", "Switch", "Battery", "Measurement"),
+
+    // Detects if a battery is charging. 0: Not charging, 1: Charging.
+    BATTERY_CHARGING("battery_charging", "Switch", "Energy", "Status"),
+
+    // Detects carbon monoxide presence. 0: No carbon monoxide, 1: Carbon monoxide detected.
+    CO("co", "Switch", "Gas", "Alarm"),
+
+    // Indicates a cold temperature. 0: Not cold, 1: Cold.
+    COLD("cold", "Switch", "Temperature", "Measurement"),
+
+    // Indicates connectivity status. 0: Disconnected, 1: Connected.
+    CONNECTIVITY("connectivity", "Switch", "Network", "Status"),
+
+    // Indicates whether a door is open or closed. 0: Door closed, 1: Door open.
+    DOOR("door", "Contact", "Door", "Point"),
+
+    // For garage door status. 0: Garage door closed, 1: Garage door open.
+    GARAGE_DOOR("garage_door", "Contact", "GarageDoor", "Point"),
+
+    // For detecting gas presence. 0: No gas, 1: Gas detected.
+    GAS("gas", "Switch", "Gas", "Alarm"),
+
+    // Indicates high temperature. 0: Not hot, 1: Hot.
+    HEAT("heat", "Switch", "Temperature", "Measurement"),
+
+    // For detecting light. 0: No light, 1: Light detected.
+    LIGHT("light", "Switch", "Light", "Control"),
+
+    // Indicates lock status. 0: Unlocked, 1: Locked.
+    LOCK("lock", "Switch", "Lock", "Control"),
+
+    // For detecting moisture. 0: Dry, 1: Moisture detected.
+    MOISTURE("moisture", "Switch", "Water", "Alarm"),
+
+    // For motion detection. 0: No motion, 1: Motion detected.
+    MOTION("motion", "Switch", "Motion", "Detection"),
+
+    // For detecting movement. 0: Stationary, 1: Moving.
+    MOVING("moving", "Switch", "Motion", "Detection"),
+
+    // For room occupancy. 0: Not occupied, 1: Occupied.
+    OCCUPANCY("occupancy", "Switch", "Motion", "Presence"),
+
+    // Generic for openings. 0: Closed, 1: Open.
+    OPENING("opening", "Contact", "Opening", "Point"),
+
+    // Indicates plug use. 0: Unplugged, 1: Plugged in.
+    PLUG("plug", "Switch", "PowerOutlet", "Control"),
+
+    // For power detection. 0: No power, 1: Power detected.
+    POWER("power", "Switch", "Energy", "Status"),
+
+    // Indicates presence at home. 0: Away, 1: Home.
+    PRESENCE("presence", "Switch", "Presence", "Presence"),
+
+    // Indicates problem detection. 0: No problem, 1: Problem detected.
+    PROBLEM("problem", "Switch", "Status", "Alarm"),
+
+    // For running status. 0: Not running, 1: Running.
+    RUNNING("running", "Switch", "Motion", "Status"),
+
+    // Indicates safety status. 0: Safe, 1: Unsafe.
+    SAFETY("safety", "Switch", "Safety", "Alarm"),
+
+    // For smoke detection. 0: No smoke, 1: Smoke detected.
+    SMOKE("smoke", "Switch", "Smoke", "Alarm"),
+
+    // For sound detection. 0: No sound, 1: Sound detected.
+    SOUND("sound", "Switch", "Sound", "Detection"),
+
+    // Indicates tampering. 0: No tampering, 1: Tampering detected.
+    TAMPER("tamper", "Switch", "Alarm", "Alarm"),
+
+    // For update status. 0: Up-to-date, 1: Update available. Note: Avoid using this device class.
+    UPDATE("update", "Switch", "Update", null),
+
+    // For vibration detection. 0: No vibration, 1: Vibration detected.
+    VIBRATION("vibration", "Switch", "Vibration", "Alarm"),
+
+    // Indicates window status. 0: Window closed, 1: Window open.
+    WINDOW("window", "Contact", "Window", "Point");
+
+    private final String deviceClass;
+
+    private final String itemType;
+    private final String category;
+    private final String semanticType;
+
+    public static BinarySensorDeviceClass fromDeviceClass(String deviceClass) {
+        for (BinarySensorDeviceClass sensorDeviceClass : BinarySensorDeviceClass.values()) {
+            if (sensorDeviceClass.getDeviceClass().equals(deviceClass)) {
+                return sensorDeviceClass;
+            }
+        }
+        return null;
+    }
+
+    public String getDeviceClass() {
+        return deviceClass;
+    }
+
+    BinarySensorDeviceClass(String deviceClass, String itemType, String category, String semanticType) {
+        this.deviceClass = deviceClass;
+        this.itemType = itemType;
+        this.category = category;
+        this.semanticType = semanticType;
+    }
+
+    public String getSemanticType() {
+        return semanticType;
+    }
+
+    public String getItemType() {
+        return itemType;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    @Override
+    public String toString() {
+        return "BinarySensorDeviceClass{" + "deviceClass='" + deviceClass + '\'' + ", itemType='" + itemType + '\''
+                + ", category='" + category + '\'' + ", measurementType='" + semanticType + '\'' + '}';
+    }
+}

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorDeviceClass.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorDeviceClass.java
@@ -8,58 +8,58 @@ public enum BinarySensorDeviceClass {
     GENERIC("generic", "Switch", "None", null),
 
     // Indicates low battery status. 0: Battery not low, 1: Battery low.
-    BATTERY("battery", "Switch", "Battery", "Measurement"),
+    BATTERY("battery", "Switch", "Battery", "LowBattery"),
 
     // Detects if a battery is charging. 0: Not charging, 1: Charging.
-    BATTERY_CHARGING("battery_charging", "Switch", "Energy", "Status"),
+    BATTERY_CHARGING("battery_charging", "Switch", "Energy", null),
 
     // Detects carbon monoxide presence. 0: No carbon monoxide, 1: Carbon monoxide detected.
     CO("co", "Switch", "Gas", "Alarm"),
 
     // Indicates a cold temperature. 0: Not cold, 1: Cold.
-    COLD("cold", "Switch", "Temperature", "Measurement"),
+    COLD("cold", "Switch", "Temperature", null),
 
     // Indicates connectivity status. 0: Disconnected, 1: Connected.
     CONNECTIVITY("connectivity", "Switch", "Network", "Status"),
 
     // Indicates whether a door is open or closed. 0: Door closed, 1: Door open.
-    DOOR("door", "Contact", "Door", "Point"),
+    DOOR("door", "Contact", "Door", "OpenState"),
 
     // For garage door status. 0: Garage door closed, 1: Garage door open.
-    GARAGE_DOOR("garage_door", "Contact", "GarageDoor", "Point"),
+    GARAGE_DOOR("garage_door", "Contact", "GarageDoor", "OpenState"),
 
     // For detecting gas presence. 0: No gas, 1: Gas detected.
     GAS("gas", "Switch", "Gas", "Alarm"),
 
     // Indicates high temperature. 0: Not hot, 1: Hot.
-    HEAT("heat", "Switch", "Temperature", "Measurement"),
+    HEAT("heat", "Switch", "Temperature", null),
 
     // For detecting light. 0: No light, 1: Light detected.
-    LIGHT("light", "Switch", "Light", "Control"),
+    LIGHT("light", "Switch", "Light", null),
 
     // Indicates lock status. 0: Unlocked, 1: Locked.
-    LOCK("lock", "Switch", "Lock", "Control"),
+    LOCK("lock", "Switch", "Lock", null),
 
     // For detecting moisture. 0: Dry, 1: Moisture detected.
     MOISTURE("moisture", "Switch", "Water", "Alarm"),
 
     // For motion detection. 0: No motion, 1: Motion detected.
-    MOTION("motion", "Switch", "Motion", "Detection"),
+    MOTION("motion", "Switch", "Motion", "Presence"),
 
     // For detecting movement. 0: Stationary, 1: Moving.
-    MOVING("moving", "Switch", "Motion", "Detection"),
+    MOVING("moving", "Switch", "Motion", null),
 
     // For room occupancy. 0: Not occupied, 1: Occupied.
     OCCUPANCY("occupancy", "Switch", "Motion", "Presence"),
 
     // Generic for openings. 0: Closed, 1: Open.
-    OPENING("opening", "Contact", "Opening", "Point"),
+    OPENING("opening", "Contact", "Opening", "OpenState"),
 
     // Indicates plug use. 0: Unplugged, 1: Plugged in.
-    PLUG("plug", "Switch", "PowerOutlet", "Control"),
+    PLUG("plug", "Switch", "PowerOutlet", null),
 
     // For power detection. 0: No power, 1: Power detected.
-    POWER("power", "Switch", "Energy", "Status"),
+    POWER("power", "Switch", "Energy", null),
 
     // Indicates presence at home. 0: Away, 1: Home.
     PRESENCE("presence", "Switch", "Presence", "Presence"),
@@ -68,28 +68,28 @@ public enum BinarySensorDeviceClass {
     PROBLEM("problem", "Switch", "Status", "Alarm"),
 
     // For running status. 0: Not running, 1: Running.
-    RUNNING("running", "Switch", "Motion", "Status"),
+    RUNNING("running", "Switch", "Motion", null),
 
     // Indicates safety status. 0: Safe, 1: Unsafe.
     SAFETY("safety", "Switch", "Safety", "Alarm"),
 
     // For smoke detection. 0: No smoke, 1: Smoke detected.
-    SMOKE("smoke", "Switch", "Smoke", "Alarm"),
+    SMOKE("smoke", "Switch", "Smoke", "Smoke"),
 
     // For sound detection. 0: No sound, 1: Sound detected.
-    SOUND("sound", "Switch", "Sound", "Detection"),
+    SOUND("sound", "Switch", "Sound", "Sound"),
 
     // Indicates tampering. 0: No tampering, 1: Tampering detected.
-    TAMPER("tamper", "Switch", "Alarm", "Alarm"),
+    TAMPER("tamper", "Switch", "Alarm", "Tampered"),
 
     // For update status. 0: Up-to-date, 1: Update available. Note: Avoid using this device class.
     UPDATE("update", "Switch", "Update", null),
 
     // For vibration detection. 0: No vibration, 1: Vibration detected.
-    VIBRATION("vibration", "Switch", "Vibration", "Alarm"),
+    VIBRATION("vibration", "Switch", "Vibration", "Tilt"),
 
     // Indicates window status. 0: Window closed, 1: Window open.
-    WINDOW("window", "Contact", "Window", "Point");
+    WINDOW("window", "Contact", "Window", "OpenState");
 
     private final String deviceClass;
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorMessageHandler.java
@@ -63,8 +63,8 @@ public class BinarySensorMessageHandler
         }
 
         ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(),
-                binarySensorDeviceClass.getItemType(), Collections.emptySet(), null,
-                tags, true, binarySensorDeviceClass.getCategory(), null, null, null);
+                binarySensorDeviceClass.getItemType(), Collections.emptySet(), null, tags, true,
+                binarySensorDeviceClass.getCategory(), null, null, null);
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorMessageHandler.java
@@ -1,5 +1,6 @@
 package no.seime.openhab.binding.esphome.internal.internal.message;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -57,10 +58,12 @@ public class BinarySensorMessageHandler
         Set<String> tags = new HashSet<>();
         if (binarySensorDeviceClass.getSemanticType() != null) {
             tags.add(binarySensorDeviceClass.getSemanticType());
+        } else {
+            tags.add("Status"); // default
         }
 
         ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(),
-                binarySensorDeviceClass.getItemType(), Set.of("OpenState") /* TODO: Is this always constant?! */, null,
+                binarySensorDeviceClass.getItemType(), Collections.emptySet(), null,
                 tags, true, binarySensorDeviceClass.getCategory(), null, null, null);
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/internal/message/BinarySensorMessageHandler.java
@@ -13,6 +13,8 @@ import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
 import org.openhab.core.types.UnDefType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.esphome.api.BinarySensorStateResponse;
 import io.esphome.api.ListEntitiesBinarySensorResponse;
@@ -22,6 +24,7 @@ import no.seime.openhab.binding.esphome.internal.internal.handler.ESPHomeHandler
 
 public class BinarySensorMessageHandler
         extends AbstractMessageHandler<ListEntitiesBinarySensorResponse, BinarySensorStateResponse> {
+    private final Logger logger = LoggerFactory.getLogger(BinarySensorMessageHandler.class);
 
     public BinarySensorMessageHandler(ESPHomeHandler handler) {
         super(handler);
@@ -45,6 +48,9 @@ public class BinarySensorMessageHandler
 
         BinarySensorDeviceClass binarySensorDeviceClass = BinarySensorDeviceClass.fromDeviceClass(deviceClass);
         if (binarySensorDeviceClass == null) {
+            logger.warn(
+                    "ESPHome Binary Sensor Device class `{}` not know to the ESPHome Native API Binding using GENERIC for {}",
+                    deviceClass, rsp.getUniqueId());
             binarySensorDeviceClass = BinarySensorDeviceClass.GENERIC;
         }
 
@@ -54,9 +60,8 @@ public class BinarySensorMessageHandler
         }
 
         ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(),
-                binarySensorDeviceClass.getItemType(), tags, null,
-                Set.of("OpenState") /* TODO: Is this always constant?! */, true, binarySensorDeviceClass.getCategory(),
-                null, null, null);
+                binarySensorDeviceClass.getItemType(), Set.of("OpenState") /* TODO: Is this always constant?! */, null,
+                tags, true, binarySensorDeviceClass.getCategory(), null, null, null);
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())


### PR DESCRIPTION
- Add new `BinarySensorDeviceClass` to handle different types of binary sensors
- Refactor `BinarySensorMessageHandler` to utilize `BinarySensorDeviceClass`
- Improve flexibility and readability in handling of different binary sensor types
- with support of AI and HI

 

- [x] TODO: check for handling of different binary PrimitiveTypes in openhab
- [x] Feedback ;) 
- [x] Add some logging for not mapped types or ambiguous cases