### PR TITLE
add reconnectInterval as parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,17 +212,18 @@ The binding uses mDNS to automatically discover devices on the network.
 
 ### `device` Thing Configuration
 
-| Name              | Type      | Description                                                                                                                            | Default  | Required | Advanced |
-|-------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------|----------|----------|----------|
-| `hostname`        | `text`    | Hostname or IP address of the device. Typically something like 'myboard.local'                                                         | N/A      | yes      | no       |
-| `port`            | `integer` | IP Port of the device                                                                                                                  | 6053     | no       | no       |
-| `encryptionKey`   | `text`    | Encryption key as defined in `api: encryption: key: <BASE64ENCODEDKEY>`. See https://esphome.io/components/api#configuration-variables | N/A      | no       | no       |
-| ~~`password`~~    | `text`    | Password to access the device if password protected. **DEPRECATED. Use `encryptionKey` instead**                                       | N/A      | no       | no       |
-| `pingInterval`    | `integer` | Seconds between sending ping requests to device to check if alive                                                                      | 10       | no       | yes      |
-| `maxPingTimeouts` | `integer` | Number of missed ping requests before deeming device unresponsive.                                                                     | 4        | no       | yes      |
-| `server`          | `text`    | Expected name of ESPHome. Used to ensure that we're communicating with the correct device                                              |          | no       | yes      |
-| `logPrefix`       | `text`    | Log prefix to use for this device.                                                                                                     | hostname | no       | yes      |
-| `deviceLogLevel`  | `text`    | ESPHome device log level to stream from the device.                                                                                    | NONE     | no       | yes      |
+| Name                | Type      | Description                                                                                                                            | Default  | Required | Advanced |
+|---------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------|----------|----------|----------|
+| `hostname`          | `text`    | Hostname or IP address of the device. Typically something like 'myboard.local'                                                         | N/A      | yes      | no       |
+| `port`              | `integer` | IP Port of the device                                                                                                                  | 6053     | no       | no       |
+| `encryptionKey`     | `text`    | Encryption key as defined in `api: encryption: key: <BASE64ENCODEDKEY>`. See https://esphome.io/components/api#configuration-variables | N/A      | no       | no       |
+| ~~`password`~~      | `text`    | Password to access the device if password protected. **DEPRECATED. Use `encryptionKey` instead**                                       | N/A      | no       | no       |
+| `reconnectInterval` | `integer` | Seconds between reconnecting to device after communication is lost or device request restart                                           | 20       | no       | yes      |
+| `pingInterval`      | `integer` | Seconds between sending ping requests to device to check if alive                                                                      | 10       | no       | yes      |
+| `maxPingTimeouts`   | `integer` | Number of missed ping requests before deeming device unresponsive.                                                                     | 4        | no       | yes      |
+| `server`            | `text`    | Expected name of ESPHome. Used to ensure that we're communicating with the correct device                                              |          | no       | yes      |
+| `logPrefix`         | `text`    | Log prefix to use for this device.                                                                                                     | hostname | no       | yes      |
+| `deviceLogLevel`    | `text`    | ESPHome device log level to stream from the device.                                                                                    | NONE     | no       | yes      |
 
 ## Channels
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/ESPHomeConfiguration.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/ESPHomeConfiguration.java
@@ -28,6 +28,8 @@ public class ESPHomeConfiguration {
 
     public int port = 6053;
 
+    public int reconnectInterval = 20;
+
     public int pingInterval = 10;
 
     public int maxPingTimeouts = 4;

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -54,7 +54,6 @@ import no.seime.openhab.binding.esphome.internal.message.statesubscription.Event
 @NonNullByDefault
 public class ESPHomeHandler extends BaseThingHandler implements CommunicationListener {
 
-    public static final int CONNECT_TIMEOUT = 20;
     private static final int API_VERSION_MAJOR = 1;
     private static final int API_VERSION_MINOR = 9;
     private static final String DEVICE_LOGGER_NAME = "ESPHOMEDEVICE";
@@ -185,7 +184,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             logger.warn("[{}] Error initial connection", logPrefix, e);
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
             if (!disposed) { // Don't reconnect if we've been disposed
-                scheduleReconnect(CONNECT_TIMEOUT * 2);
+                scheduleReconnect(config.reconnectInterval);
             }
         }
     }
@@ -295,7 +294,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             frameHelper.close();
             cancelPingWatchdog();
             connectionState = ConnectionState.UNINITIALIZED;
-            scheduleReconnect(CONNECT_TIMEOUT * 2);
+            scheduleReconnect(config.reconnectInterval);
         }
     }
 
@@ -308,14 +307,14 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             cancelPingWatchdog();
             frameHelper.close();
             connectionState = ConnectionState.UNINITIALIZED;
-            scheduleReconnect(CONNECT_TIMEOUT * 2);
+            scheduleReconnect(config.reconnectInterval);
         }
     }
 
     private void remoteDisconnect() {
         eventSubscriber.removeEventSubscriptions(this);
         if (!disposed) {
-            int reconnectDelaySeconds = CONNECT_TIMEOUT;
+            int reconnectDelaySeconds = config.reconnectInterval;
             updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.NONE, String.format(
                     "ESPHome device requested disconnect. Will reconnect in %d seconds", reconnectDelaySeconds));
 
@@ -452,7 +451,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                     updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR,
                             String.format("ESPHome did not respond to ping requests. %d pings sent with %d s delay",
                                     config.maxPingTimeouts, config.pingInterval));
-                    scheduleReconnect(10);
+                    scheduleReconnect(config.reconnectInterval);
 
                 } else {
 

--- a/src/main/resources/OH-INF/thing/thing-types.xml
+++ b/src/main/resources/OH-INF/thing/thing-types.xml
@@ -55,6 +55,13 @@
 				<description>DEPRECATED: Password to access the device. Instead, use encryptionKey for encrypted connection.</description>
 			</parameter>
 
+			<parameter name="reconnectInterval" type="integer" min="0" required="false" groupName="timeout">
+				<label>Reconnect interval in seconds</label>
+				<default>20</default>
+				<description>Seconds between reconnect attempts when connection is lost or device restart.
+				</description>
+				<advanced>true</advanced>
+			</parameter>
 			<parameter name="pingInterval" type="integer" min="1" required="false" groupName="timeout">
 				<label>Ping interval in seconds</label>
 				<default>10</default>


### PR DESCRIPTION
I've encountered a similar issue to the one discussed in [issue #25](https://github.com/seime/openhab-esphome/issues/25) regarding deep sleep behavior. After some testing, I believe introducing a single parameter could help address these concerns.

In my setup, I created a "smartknob" on ESPHome, which connects to OpenHAB. This device remains in deep sleep 99% of the time, only waking up when picked up. Waiting 20-40 seconds for OpenHAB to ping the device upon waking can be quite inconvenient. To improve this, I've made the ping interval configurable, with a default value of 20 seconds as it was previously.

Please let me know your thoughts on this PR and whether it might help other use cases as well.