### PR TITLE
Fix using changed encryption key without disabling/re-enabling

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -185,13 +185,6 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     }
 
     @Override
-    public void handleConfigurationUpdate(Map<String, Object> configurationParameters) {
-        dispose();
-        initialize();
-        super.handleConfigurationUpdate(configurationParameters);
-    }
-
-    @Override
     public void handleRemoval() {
         dynamicChannelTypeProvider.removeChannelTypesForThing(thing.getUID());
         super.handleRemoval();


### PR DESCRIPTION
Like right after you add the device from the inbox

Note that the super method handles disposing and re-initializing automatically: https://github.com/openhab/openhab-core/blob/4.1.x/bundles/org.openhab.core.thing/src/main/java/org/openhab/core/thing/binding/BaseThingHandler.java#L95

The bug is that with the old code it was re-initializing before the config change was committed, so connect() wasn't seeing the new value. A disable/re-enable worked around it.