### PR TITLE
Handle unit conversions on commands to number entities

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
@@ -161,7 +161,7 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
         return null;
     }
 
-    private String transformUnit(String unitOfMeasurement) {
+    protected String transformUnit(String unitOfMeasurement) {
         return switch (unitOfMeasurement) {
             case "seconds" -> "s";
             default -> unitOfMeasurement;


### PR DESCRIPTION
For example, if the device exposes the number as mm, but you link it to an item with m because it makes more sense that way, incoming commands will come in m, so we need to handle it.