### PR TITLE
Separate state and command descriptions for locks

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -26,8 +26,10 @@ import org.openhab.core.thing.*;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.RefreshType;
 import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +66,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
 
     private final ConnectionSelector connectionSelector;
     private final ESPChannelTypeProvider dynamicChannelTypeProvider;
+    private final ESPStateDescriptionProvider stateDescriptionProvider;
     private final Map<String, AbstractMessageHandler<? extends GeneratedMessage, ? extends GeneratedMessage>> commandTypeToHandlerMap = new HashMap<>();
     private final Map<Class<? extends GeneratedMessage>, AbstractMessageHandler<? extends GeneratedMessage, ? extends GeneratedMessage>> classToHandlerMap = new HashMap<>();
     private final List<Channel> dynamicChannels = new ArrayList<>();
@@ -89,12 +92,13 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     private ESPHomeBluetoothProxyHandler espHomeBluetoothProxyHandler;
 
     public ESPHomeHandler(Thing thing, ConnectionSelector connectionSelector,
-            ESPChannelTypeProvider dynamicChannelTypeProvider, ESPHomeEventSubscriber eventSubscriber,
-            MonitoredScheduledThreadPoolExecutor executorService, KeySequentialExecutor packetProcessor,
-            @Nullable String defaultEncryptionKey) {
+            ESPChannelTypeProvider dynamicChannelTypeProvider, ESPStateDescriptionProvider stateDescriptionProvider,
+            ESPHomeEventSubscriber eventSubscriber, MonitoredScheduledThreadPoolExecutor executorService,
+            KeySequentialExecutor packetProcessor, @Nullable String defaultEncryptionKey) {
         super(thing);
         this.connectionSelector = connectionSelector;
         this.dynamicChannelTypeProvider = dynamicChannelTypeProvider;
+        this.stateDescriptionProvider = stateDescriptionProvider;
         logPrefix = thing.getUID().getId();
         this.eventSubscriber = eventSubscriber;
         this.executorService = executorService;
@@ -167,7 +171,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     public void dispose() {
         disposed = true;
         eventSubscriber.removeEventSubscriptions(this);
-        setUndefToAllChannels();
+        stateDescriptionProvider.removeDescriptionsForThing(thing.getUID());
         cancelConnectFuture();
         if (frameHelper != null) {
             cancelPingWatchdog();
@@ -553,6 +557,14 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
 
     public void addChannelType(ChannelType channelType) {
         dynamicChannelTypeProvider.putChannelType(channelType);
+    }
+
+    public void addDescription(ChannelUID channelUID, StateDescription stateDescription) {
+        stateDescriptionProvider.setDescription(channelUID, stateDescription);
+    }
+
+    public void addDescription(ChannelUID channelUID, CommandDescription commandDescription) {
+        stateDescriptionProvider.setDescription(channelUID, commandDescription);
     }
 
     public void addChannel(Channel channel) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -25,12 +25,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.thing.*;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.type.ChannelType;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.CommandDescription;
-import org.openhab.core.types.RefreshType;
-import org.openhab.core.types.State;
-import org.openhab.core.types.StateDescription;
-import org.openhab.core.types.UnDefType;
+import org.openhab.core.types.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +167,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
         disposed = true;
         eventSubscriber.removeEventSubscriptions(this);
         stateDescriptionProvider.removeDescriptionsForThing(thing.getUID());
+        setUndefToAllChannels();
         cancelConnectFuture();
         if (frameHelper != null) {
             cancelPingWatchdog();

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerFactory.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerFactory.java
@@ -64,6 +64,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
     }
 
     private final ESPChannelTypeProvider dynamicChannelTypeProvider;
+    private final ESPStateDescriptionProvider stateDescriptionProvider;
     private final ESPHomeEventSubscriber eventSubscriber;
 
     private final ThingRegistry thingRegistry;
@@ -73,6 +74,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
 
     @Activate
     public ESPHomeHandlerFactory(@Reference ESPChannelTypeProvider dynamicChannelTypeProvider,
+            @Reference ESPStateDescriptionProvider stateDescriptionProvider,
             @Reference ESPHomeEventSubscriber eventSubscriber, @Reference ThingRegistry thingRegistry)
             throws IOException {
         scheduler = new MonitoredScheduledThreadPoolExecutor(4, r -> {
@@ -87,6 +89,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
         packetExecutor = new KeySequentialExecutor(scheduler);
 
         this.dynamicChannelTypeProvider = dynamicChannelTypeProvider;
+        this.stateDescriptionProvider = stateDescriptionProvider;
         this.eventSubscriber = eventSubscriber;
         this.thingRegistry = thingRegistry;
 
@@ -98,8 +101,8 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
         ThingTypeUID thingTypeUID = thing.getThingTypeUID();
 
         if (BindingConstants.THING_TYPE_DEVICE.equals(thingTypeUID)) {
-            return new ESPHomeHandler(thing, connectionSelector, dynamicChannelTypeProvider, eventSubscriber, scheduler,
-                    packetExecutor, defaultEncryptionKey);
+            return new ESPHomeHandler(thing, connectionSelector, dynamicChannelTypeProvider, stateDescriptionProvider,
+                    eventSubscriber, scheduler, packetExecutor, defaultEncryptionKey);
         } else if (BindingConstants.THING_TYPE_BLE_PROXY.equals(thingTypeUID)) {
             ESPHomeBluetoothProxyHandler handler = new ESPHomeBluetoothProxyHandler((Bridge) thing, thingRegistry);
             registerBluetoothAdapter(handler);

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPStateDescriptionProvider.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPStateDescriptionProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2025 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package no.seime.openhab.binding.esphome.internal.handler;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.type.DynamicCommandDescriptionProvider;
+import org.openhab.core.thing.type.DynamicStateDescriptionProvider;
+import org.openhab.core.types.CommandDescription;
+import org.openhab.core.types.StateDescription;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides state and command descriptions for individual channels.
+ *
+ * @author Cody Cutrer- Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class, DynamicCommandDescriptionProvider.class,
+        ESPStateDescriptionProvider.class })
+@NonNullByDefault
+public class ESPStateDescriptionProvider implements DynamicStateDescriptionProvider, DynamicCommandDescriptionProvider {
+
+    private final Map<ChannelUID, StateDescription> stateDescriptions = new ConcurrentHashMap<>();
+    private final Map<ChannelUID, CommandDescription> commandDescriptions = new ConcurrentHashMap<>();
+    private final Logger logger = LoggerFactory.getLogger(ESPStateDescriptionProvider.class);
+
+    @Activate
+    public ESPStateDescriptionProvider() {
+    }
+
+    /**
+     * Set a state description for a channel. This description will be used when preparing the channel state by
+     * the framework for presentation. A previous description, if existed, will be replaced.
+     *
+     * @param channelUID channel UID
+     * @param description state description for the channel
+     */
+    public void setDescription(ChannelUID channelUID, StateDescription description) {
+        stateDescriptions.put(channelUID, description);
+    }
+
+    /**
+     * Set a command description for a channel.
+     * A previous description, if existed, will be replaced.
+     *
+     * @param channelUID channel UID
+     * @param description command description for the channel
+     */
+    public void setDescription(ChannelUID channelUID, CommandDescription description) {
+        commandDescriptions.put(channelUID, description);
+    }
+
+    public void removeDescriptionsForThing(ThingUID thingUID) {
+        stateDescriptions.keySet().removeIf(channelUID -> channelUID.getThingUID().equals(thingUID));
+        commandDescriptions.keySet().removeIf(channelUID -> channelUID.getThingUID().equals(thingUID));
+    }
+
+    @Override
+    public @Nullable StateDescription getStateDescription(Channel channel,
+            @Nullable StateDescription originalStateDescription, @Nullable Locale locale) {
+        return stateDescriptions.get(channel.getUID());
+    }
+
+    @Override
+    public @Nullable CommandDescription getCommandDescription(Channel channel,
+            @Nullable CommandDescription originalCommandDescription, @Nullable Locale locale) {
+        return commandDescriptions.get(channel.getUID());
+    }
+}

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
@@ -68,25 +68,25 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
         return channelType;
     }
 
-    protected StateDescription readOnlyStateDescription() {
+    protected static StateDescription readOnlyStateDescription() {
         return StateDescriptionFragmentBuilder.create().withReadOnly(true).build().toStateDescription();
     }
 
-    protected StateDescription addStateDescription(String pattern) {
-        return addStateDescription(pattern, false);
+    protected static StateDescription patternStateDescription(String pattern) {
+        return patternStateDescription(pattern, false);
     }
 
-    protected StateDescription addStateDescription(String pattern, boolean readOnly) {
+    protected static StateDescription patternStateDescription(String pattern, boolean readOnly) {
         return StateDescriptionFragmentBuilder.create().withPattern(pattern).withReadOnly(readOnly).build()
                 .toStateDescription();
     }
 
-    protected StateDescription addStateDescription(@Nullable String pattern, @Nullable BigDecimal step,
+    protected static StateDescription numericStateDescription(@Nullable String pattern, @Nullable BigDecimal step,
             @Nullable BigDecimal min, @Nullable BigDecimal max) {
-        return addStateDescription(pattern, step, min, max, false);
+        return numericStateDescription(pattern, step, min, max, false);
     }
 
-    protected StateDescription addStateDescription(@Nullable String pattern, @Nullable BigDecimal step,
+    protected static StateDescription numericStateDescription(@Nullable String pattern, @Nullable BigDecimal step,
             @Nullable BigDecimal min, @Nullable BigDecimal max, boolean readOnly) {
         StateDescriptionFragmentBuilder builder = StateDescriptionFragmentBuilder.create().withReadOnly(readOnly);
 
@@ -109,11 +109,11 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
         return builder.build().toStateDescription();
     }
 
-    protected StateDescription addStateDescription(final Collection<?> options) {
-        return addStateDescription(options, false);
+    protected static StateDescription optionListStateDescription(final Collection<?> options) {
+        return optionListStateDescription(options, false);
     }
 
-    protected StateDescription addStateDescription(final Collection<?> options, boolean readOnly) {
+    protected static StateDescription optionListStateDescription(final Collection<?> options, boolean readOnly) {
 
         StateDescriptionFragmentBuilder builder = StateDescriptionFragmentBuilder.create().withPattern("%s")
                 .withReadOnly(readOnly);
@@ -125,7 +125,7 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
         return builder.build().toStateDescription();
     }
 
-    protected CommandDescription addCommandDescription(Collection<?> options) {
+    protected static CommandDescription optionListCommandDescription(Collection<?> options) {
         CommandDescriptionBuilder builder = CommandDescriptionBuilder.create();
 
         final List<CommandOption> commandOptions = options.stream()

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/BinarySensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/BinarySensorMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -66,14 +65,13 @@ public class BinarySensorMessageHandler
                 binarySensorDeviceClass != null ? binarySensorDeviceClass.getCategory() : null);
 
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(),
-                binarySensorDeviceClass.getItemType(), Collections.emptySet(), null, tags, true, icon, null, null, null,
-                rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                binarySensorDeviceClass.getItemType(), tags, icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(binarySensorDeviceClass.getItemType()).withConfiguration(configuration).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, readOnlyStateDescription());
     }
 
     public void handleState(BinarySensorStateResponse rsp) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/ButtonMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/ButtonMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -46,9 +45,8 @@ public class ButtonMessageHandler extends AbstractMessageHandler<ListEntitiesBut
 
         String icon = getChannelIcon(rsp.getIcon(), "switch");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Switch", Collections.emptySet(),
-                null, Set.of("Switch"), false, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Switch", Set.of("Switch"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/ClimateMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/ClimateMessageHandler.java
@@ -1,7 +1,9 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
@@ -194,7 +196,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_TEMPERATURE,
                     "Current temperature", ITEM_TYPE_TEMPERATURE, Set.of(SEMANTIC_TYPE_MEASUREMENT, "Temperature"),
                     "temperature", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription("%.1f %unit%",
+            StateDescription stateDescription = numericStateDescription("%.1f %unit%",
                     rsp.getVisualCurrentTemperatureStep() == 0f ? null
                             : BigDecimal.valueOf(rsp.getVisualCurrentTemperatureStep()),
                     rsp.getVisualMinTemperature() == 0f ? null
@@ -214,7 +216,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             ChannelType channelTypeTargetHumidity = addChannelType(rsp.getUniqueId() + CHANNEL_TARGET_HUMIDITY,
                     "Target humidity", ITEM_TYPE_NUMBER_DIMENSIONLESS, Set.of(SEMANTIC_TYPE_SETPOINT, "Humidity"),
                     "humidity", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription("%.0f %unit%", null,
+            StateDescription stateDescription = numericStateDescription("%.0f %unit%", null,
                     BigDecimal.valueOf(rsp.getVisualMinHumidity()), BigDecimal.valueOf(rsp.getVisualMaxHumidity()));
             Channel channelTargetHumidity = ChannelBuilder
                     .create(createChannelUID(rsp.getObjectId(), CHANNEL_TARGET_HUMIDITY))
@@ -229,7 +231,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_HUMIDITY, "Current humidity",
                     ITEM_TYPE_NUMBER_DIMENSIONLESS, Set.of(SEMANTIC_TYPE_MEASUREMENT, "Humidity"), "humidity",
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription("%.0f %unit%", true);
+            StateDescription stateDescription = patternStateDescription("%.0f %unit%", true);
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_CURRENT_HUMIDITY))
                     .withLabel(createLabel(rsp.getName(), "Current humidity")).withKind(ChannelKind.STATE)
                     .withType(channelType.getUID()).withAcceptedItemType(ITEM_TYPE_NUMBER_DIMENSIONLESS)
@@ -241,7 +243,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
         if (rsp.getSupportedModesCount() > 0) {
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_MODE, "Mode", itemTypeString,
                     Set.of(SEMANTIC_TYPE_CONTROL), "climate", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(
+            StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedModesList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_MODE))
                     .withLabel(createLabel(rsp.getName(), "Mode")).withKind(ChannelKind.STATE)
@@ -252,7 +254,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
         if (rsp.getSupportsAction()) {
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_ACTION, "Action", itemTypeString,
                     Set.of(SEMANTIC_TYPE_STATUS), "climate", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(ACTIONS, true);
+            StateDescription stateDescription = optionListStateDescription(ACTIONS, true);
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_ACTION))
                     .withLabel(createLabel(rsp.getName(), "Action")).withKind(ChannelKind.STATE)
                     .withType(channelType.getUID()).withAcceptedItemType(itemTypeString)
@@ -262,7 +264,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
         if (rsp.getSupportedFanModesCount() > 0) {
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_FAN_MODE, "Fan Mode", itemTypeString,
                     Set.of(SEMANTIC_TYPE_CONTROL, "Wind"), "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(
+            StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedFanModesList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_FAN_MODE))
                     .withLabel(createLabel(rsp.getName(), "Fan Mode")).withKind(ChannelKind.STATE)
@@ -274,7 +276,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CUSTOM_FAN_MODE, "Custom Fan Mode",
                     itemTypeString, Set.of(SEMANTIC_TYPE_CONTROL, "Wind"), "fan", rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(rsp.getSupportedCustomFanModesList());
+            StateDescription stateDescription = optionListStateDescription(rsp.getSupportedCustomFanModesList());
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_CUSTOM_FAN_MODE))
                     .withLabel(createLabel(rsp.getName(), "Custom Fan Mode")).withKind(ChannelKind.STATE)
                     .withType(channelType.getUID()).withAcceptedItemType(itemTypeString)
@@ -285,7 +287,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
         if (rsp.getSupportedPresetsCount() > 0) {
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_PRESET, "Preset", itemTypeString,
                     Set.of(SEMANTIC_TYPE_CONTROL), "climate", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(
+            StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedPresetsList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_PRESET))
                     .withLabel(createLabel(rsp.getName(), "Preset")).withKind(ChannelKind.STATE)
@@ -297,7 +299,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CUSTOM_PRESET, "Custom Preset",
                     itemTypeString, Set.of(SEMANTIC_TYPE_CONTROL), "climate", rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(rsp.getSupportedCustomPresetsList());
+            StateDescription stateDescription = optionListStateDescription(rsp.getSupportedCustomPresetsList());
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_CUSTOM_PRESET))
                     .withLabel(createLabel(rsp.getName(), "Custom Preset")).withKind(ChannelKind.STATE)
                     .withType(channelType.getUID()).withAcceptedItemType(itemTypeString)
@@ -309,7 +311,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_SWING_MODE, "Swing Mode",
                     itemTypeString, Set.of(SEMANTIC_TYPE_CONTROL, "Wind"), "fan", rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(
+            StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedSwingModesList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_SWING_MODE))
                     .withAcceptedItemType(itemTypeString).withLabel(createLabel(rsp.getName(), "Swing Mode"))
@@ -323,7 +325,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
         ChannelType channelTypeTargetTemperature = addChannelType(rsp.getUniqueId() + channelID, label,
                 ITEM_TYPE_TEMPERATURE, Set.of(SEMANTIC_TYPE_SETPOINT, "Temperature"), "temperature",
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription("%.1f %unit%",
+        StateDescription stateDescription = numericStateDescription("%.1f %unit%",
                 rsp.getVisualTargetTemperatureStep() == 0f ? null
                         : BigDecimal.valueOf(rsp.getVisualTargetTemperatureStep()),
                 rsp.getVisualMinTemperature() == 0f ? null

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
@@ -180,7 +180,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
             ChannelType channelTypePosition = addChannelType(rsp.getUniqueId() + CHANNEL_POSITION, "Position",
                     deviceClass.getItemType(), Set.of("OpenLevel"), icon, rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription("%d %%");
+            StateDescription stateDescription = patternStateDescription("%d %%");
 
             Channel channelPosition = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_POSITION))
                     .withLabel(createLabel(rsp.getName(), "Position")).withKind(ChannelKind.STATE)
@@ -192,7 +192,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
             ChannelType channelTypeTilt = addChannelType(rsp.getUniqueId() + CHANNEL_TILT, "Tilt",
                     deviceClass.getItemType(), Set.of("Tilt"), icon, rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription("%d %%");
+            StateDescription stateDescription = patternStateDescription("%d %%");
 
             Channel channelTilt = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_TILT))
                     .withLabel(createLabel(rsp.getName(), "Tilt")).withKind(ChannelKind.STATE)
@@ -205,7 +205,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
         ChannelType channelTypeState = addChannelType(rsp.getUniqueId() + LEGACY_CHANNEL_STATE, "Legacy State",
                 deviceClass.getItemType(), Set.of("OpenClose"), icon, rsp.getEntityCategory(),
                 rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription("%s");
+        StateDescription stateDescription = patternStateDescription("%s");
 
         Channel channelState = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), LEGACY_CHANNEL_STATE))
                 .withLabel(createLabel(rsp.getName(), "Legacy State")).withKind(ChannelKind.STATE)
@@ -217,7 +217,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
         ChannelType channelTypeCurrentOperation = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_OPERATION,
                 "Current operation", "String", Set.of("Status"), "motion", rsp.getEntityCategory(),
                 rsp.getDisabledByDefault());
-        stateDescription = addStateDescription(Set.of("IDLE", "IS_OPENING", "IS_CLOSING"), true);
+        stateDescription = optionListStateDescription(Set.of("IDLE", "IS_OPENING", "IS_CLOSING"), true);
 
         Channel channelCurrentOperation = ChannelBuilder
                 .create(createChannelUID(rsp.getObjectId(), CHANNEL_CURRENT_OPERATION))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -12,6 +11,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -178,49 +178,53 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
 
         if (rsp.getSupportsPosition()) {
             ChannelType channelTypePosition = addChannelType(rsp.getUniqueId() + CHANNEL_POSITION, "Position",
-                    deviceClass.getItemType(), Collections.emptyList(), "%d %%", Set.of("OpenLevel"), false, icon, null,
-                    null, null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                    deviceClass.getItemType(), Set.of("OpenLevel"), icon, rsp.getEntityCategory(),
+                    rsp.getDisabledByDefault());
+            StateDescription stateDescription = addStateDescription("%d %%");
 
             Channel channelPosition = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_POSITION))
                     .withLabel(createLabel(rsp.getName(), "Position")).withKind(ChannelKind.STATE)
                     .withType(channelTypePosition.getUID()).withAcceptedItemType(deviceClass.getItemType())
                     .withConfiguration(configuration(rsp.getKey(), CHANNEL_POSITION, COMMAND_CLASS_COVER)).build();
-            super.registerChannel(channelPosition, channelTypePosition);
+            super.registerChannel(channelPosition, channelTypePosition, stateDescription);
         }
         if (rsp.getSupportsTilt()) {
             ChannelType channelTypeTilt = addChannelType(rsp.getUniqueId() + CHANNEL_TILT, "Tilt",
-                    deviceClass.getItemType(), Collections.emptyList(), "%d %%", Set.of("Tilt"), false, icon, null,
-                    null, null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                    deviceClass.getItemType(), Set.of("Tilt"), icon, rsp.getEntityCategory(),
+                    rsp.getDisabledByDefault());
+            StateDescription stateDescription = addStateDescription("%d %%");
 
             Channel channelTilt = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_TILT))
                     .withLabel(createLabel(rsp.getName(), "Tilt")).withKind(ChannelKind.STATE)
                     .withType(channelTypeTilt.getUID()).withAcceptedItemType(deviceClass.getItemType())
                     .withConfiguration(configuration(rsp.getKey(), CHANNEL_TILT, COMMAND_CLASS_COVER)).build();
-            super.registerChannel(channelTilt, channelTypeTilt);
+            super.registerChannel(channelTilt, channelTypeTilt, stateDescription);
         }
 
         // Legacy state
         ChannelType channelTypeState = addChannelType(rsp.getUniqueId() + LEGACY_CHANNEL_STATE, "Legacy State",
-                deviceClass.getItemType(), Collections.emptyList(), "%s", Set.of("OpenClose"), false, icon, null, null,
-                null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                deviceClass.getItemType(), Set.of("OpenClose"), icon, rsp.getEntityCategory(),
+                rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription("%s");
 
         Channel channelState = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), LEGACY_CHANNEL_STATE))
                 .withLabel(createLabel(rsp.getName(), "Legacy State")).withKind(ChannelKind.STATE)
                 .withType(channelTypeState.getUID()).withAcceptedItemType(deviceClass.getItemType())
                 .withConfiguration(configuration(rsp.getKey(), LEGACY_CHANNEL_STATE, COMMAND_CLASS_COVER)).build();
-        super.registerChannel(channelState, channelTypeState);
+        super.registerChannel(channelState, channelTypeState, stateDescription);
 
         // Operation status
         ChannelType channelTypeCurrentOperation = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_OPERATION,
-                "Current operation", "String", Set.of("IDLE", "IS_OPENING", "IS_CLOSING"), "%s", Set.of("Status"), true,
-                "motion", null, null, null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                "Current operation", "String", Set.of("Status"), "motion", rsp.getEntityCategory(),
+                rsp.getDisabledByDefault());
+        stateDescription = addStateDescription(Set.of("IDLE", "IS_OPENING", "IS_CLOSING"), true);
 
         Channel channelCurrentOperation = ChannelBuilder
                 .create(createChannelUID(rsp.getObjectId(), CHANNEL_CURRENT_OPERATION))
                 .withLabel(createLabel(rsp.getName(), "Current operation")).withKind(ChannelKind.STATE)
                 .withType(channelTypeCurrentOperation.getUID()).withAcceptedItemType("String")
                 .withConfiguration(configuration(rsp.getKey(), CHANNEL_CURRENT_OPERATION, COMMAND_CLASS_COVER)).build();
-        super.registerChannel(channelCurrentOperation, channelTypeCurrentOperation);
+        super.registerChannel(channelCurrentOperation, channelTypeCurrentOperation, stateDescription);
     }
 
     public void handleState(CoverStateResponse rsp) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateMessageHandler.java
@@ -52,7 +52,7 @@ public class DateMessageHandler extends AbstractMessageHandler<ListEntitiesDateR
         String itemType = "DateTime";
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription("%1$tY-%1$tm-%1$td");
+        StateDescription stateDescription = patternStateDescription("%1$tY-%1$tm-%1$td");
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateMessageHandler.java
@@ -2,7 +2,6 @@ package no.seime.openhab.binding.esphome.internal.message;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -14,6 +13,7 @@ import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,15 +50,15 @@ public class DateMessageHandler extends AbstractMessageHandler<ListEntitiesDateR
         String icon = getChannelIcon(rsp.getIcon(), "time");
 
         String itemType = "DateTime";
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptySet(),
-                "%1$tY-%1$tm-%1$td", Set.of("Status"), false, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription("%1$tY-%1$tm-%1$td");
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription);
     }
 
     @Override

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateTimeMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateTimeMessageHandler.java
@@ -1,7 +1,6 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
 import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -12,6 +11,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,15 +49,15 @@ public class DateTimeMessageHandler
         String icon = getChannelIcon(rsp.getIcon(), "time");
 
         String itemType = "DateTime";
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptySet(),
-                "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Set.of("Status"), false, icon, null, null, null,
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS");
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription);
     }
 
     @Override

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateTimeMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateTimeMessageHandler.java
@@ -51,7 +51,7 @@ public class DateTimeMessageHandler
         String itemType = "DateTime";
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS");
+        StateDescription stateDescription = patternStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS");
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/FanMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/FanMessageHandler.java
@@ -2,7 +2,6 @@ package no.seime.openhab.binding.esphome.internal.message;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -15,6 +14,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,8 +187,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
         String icon = getChannelIcon(rsp.getIcon(), "fan");
 
         ChannelType channelTypeState = addChannelType(rsp.getUniqueId() + CHANNEL_STATE, "State", "Switch",
-                Collections.emptySet(), null, Set.of("Switch"), false, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+                Set.of("Switch"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channelState = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_STATE))
                 .withLabel(createLabel(rsp.getName(), "State")).withKind(ChannelKind.STATE)
@@ -199,8 +198,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
 
         if (rsp.getSupportsOscillation()) {
             ChannelType channelTypeOscillation = addChannelType(rsp.getUniqueId() + CHANNEL_OSCILLATION, "Oscillation",
-                    "Switch", Collections.emptySet(), null, Set.of("Switch"), false, icon, null, null, null,
-                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                    "Switch", Set.of("Switch"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channelOscillation = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_OSCILLATION))
                     .withLabel(createLabel(rsp.getName(), "Oscillation")).withKind(ChannelKind.STATE)
@@ -212,16 +210,16 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
         if (rsp.getSupportsDirection()) {
 
             ChannelType channelTypeDirection = addChannelType(rsp.getUniqueId() + CHANNEL_DIRECTION, "Direction",
-                    "String",
+                    "String", null, "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            StateDescription stateDescription = addStateDescription(
                     Arrays.stream(FanDirection.values()).filter(e -> e != FanDirection.UNRECOGNIZED)
-                            .map(e -> stripEnumPrefix(e)).collect(Collectors.toList()),
-                    "%s", null, false, "fan", null, null, null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                            .map(e -> stripEnumPrefix(e)).collect(Collectors.toList()));
 
             Channel channelDirection = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_DIRECTION))
                     .withLabel(createLabel(rsp.getName(), "Direction")).withKind(ChannelKind.STATE)
                     .withType(channelTypeDirection.getUID()).withAcceptedItemType("String")
                     .withConfiguration(configuration(rsp.getKey(), CHANNEL_DIRECTION, COMMAND_CLASS_FAN)).build();
-            super.registerChannel(channelDirection, channelTypeDirection);
+            super.registerChannel(channelDirection, channelTypeDirection, stateDescription);
 
         }
 
@@ -230,27 +228,27 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
             int supportedSpeedLevels = rsp.getSupportedSpeedCount();
 
             ChannelType channelTypeSpeed = addChannelType(rsp.getUniqueId() + CHANNEL_SPEED_LEVEL, "Speed", "Dimmer",
-                    Collections.emptySet(), null, Set.of("Speed"), false, icon,
-                    BigDecimal.valueOf(100 / supportedSpeedLevels), BigDecimal.ZERO, BigDecimal.valueOf(100),
-                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                    Set.of("Speed"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            StateDescription stateDescription = addStateDescription(null,
+                    BigDecimal.valueOf(100 / supportedSpeedLevels), BigDecimal.ZERO, BigDecimal.valueOf(100));
 
             Channel channelSpeed = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_SPEED_LEVEL))
                     .withLabel(createLabel(rsp.getName(), "Speed")).withKind(ChannelKind.STATE)
                     .withType(channelTypeSpeed.getUID()).withAcceptedItemType("Dimmer")
                     .withConfiguration(configuration(rsp.getKey(), CHANNEL_SPEED_LEVEL, COMMAND_CLASS_FAN)).build();
-            super.registerChannel(channelSpeed, channelTypeSpeed);
+            super.registerChannel(channelSpeed, channelTypeSpeed, stateDescription);
 
         }
 
         if (rsp.getSupportedPresetModesCount() > 0) {
             ChannelType channelTypePreset = addChannelType(rsp.getUniqueId() + CHANNEL_PRESET, "Preset", "String",
-                    rsp.getSupportedPresetModesList(), "%s", Set.of("Setpoint"), false, "fan", null, null, null,
-                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                    Set.of("Setpoint"), "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            StateDescription stateDescription = addStateDescription(rsp.getSupportedPresetModesList());
             Channel channelPreset = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_PRESET))
                     .withLabel(createLabel(rsp.getName(), "Preset")).withKind(ChannelKind.STATE)
                     .withType(channelTypePreset.getUID()).withAcceptedItemType("String")
                     .withConfiguration(configuration(rsp.getKey(), CHANNEL_PRESET, COMMAND_CLASS_FAN)).build();
-            super.registerChannel(channelPreset, channelTypePreset);
+            super.registerChannel(channelPreset, channelTypePreset, stateDescription);
         }
     }
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/FanMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/FanMessageHandler.java
@@ -211,7 +211,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
 
             ChannelType channelTypeDirection = addChannelType(rsp.getUniqueId() + CHANNEL_DIRECTION, "Direction",
                     "String", null, "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(
+            StateDescription stateDescription = optionListStateDescription(
                     Arrays.stream(FanDirection.values()).filter(e -> e != FanDirection.UNRECOGNIZED)
                             .map(e -> stripEnumPrefix(e)).collect(Collectors.toList()));
 
@@ -229,7 +229,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
 
             ChannelType channelTypeSpeed = addChannelType(rsp.getUniqueId() + CHANNEL_SPEED_LEVEL, "Speed", "Dimmer",
                     Set.of("Speed"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(null,
+            StateDescription stateDescription = numericStateDescription(null,
                     BigDecimal.valueOf(100 / supportedSpeedLevels), BigDecimal.ZERO, BigDecimal.valueOf(100));
 
             Channel channelSpeed = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_SPEED_LEVEL))
@@ -243,7 +243,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
         if (rsp.getSupportedPresetModesCount() > 0) {
             ChannelType channelTypePreset = addChannelType(rsp.getUniqueId() + CHANNEL_PRESET, "Preset", "String",
                     Set.of("Setpoint"), "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(rsp.getSupportedPresetModesList());
+            StateDescription stateDescription = optionListStateDescription(rsp.getSupportedPresetModesList());
             Channel channelPreset = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_PRESET))
                     .withLabel(createLabel(rsp.getName(), "Preset")).withKind(ChannelKind.STATE)
                     .withType(channelTypePreset.getUID()).withAcceptedItemType("String")

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/LightMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/LightMessageHandler.java
@@ -1,6 +1,9 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.openhab.core.config.core.Configuration;
@@ -138,7 +141,7 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
             // Create effects channel
             ChannelType channelType = addChannelType(rsp.getUniqueId() + "-effects", rsp.getName(), "String",
                     Set.of("Setpoint"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            StateDescription stateDescription = addStateDescription(rsp.getEffectsList());
+            StateDescription stateDescription = optionListStateDescription(rsp.getEffectsList());
 
             Channel channel = ChannelBuilder
                     .create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId() + "-effects"))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/LightMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/LightMessageHandler.java
@@ -14,6 +14,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.util.ColorUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -103,9 +104,8 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
 
         if (capabilities.contains(LightColorCapability.RGB)) {
             // Go for a single Color channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Color", Collections.emptySet(),
-                    null, Set.of("Light"), false, icon, null, null, null, rsp.getEntityCategory(),
-                    rsp.getDisabledByDefault());
+            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Color", Set.of("Light"), icon,
+                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                     .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
@@ -114,9 +114,8 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
             super.registerChannel(channel, channelType);
         } else if (capabilities.contains(LightColorCapability.BRIGHTNESS)) {
             // Go for a single Dimmer channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Dimmer", Collections.emptySet(),
-                    null, Set.of("Light"), false, icon, null, null, null, rsp.getEntityCategory(),
-                    rsp.getDisabledByDefault());
+            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Dimmer", Set.of("Light"), icon,
+                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                     .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
@@ -125,9 +124,8 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
             super.registerChannel(channel, channelType);
         } else if (capabilities.contains(LightColorCapability.ON_OFF)) {
             // Go for a single Switch channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Switch", Collections.emptySet(),
-                    null, Set.of("Light"), false, icon, null, null, null, rsp.getEntityCategory(),
-                    rsp.getDisabledByDefault());
+            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Switch", Set.of("Light"), icon,
+                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                     .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
@@ -139,8 +137,8 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
         if (rsp.getEffectsCount() > 0) {
             // Create effects channel
             ChannelType channelType = addChannelType(rsp.getUniqueId() + "-effects", rsp.getName(), "String",
-                    new ArrayList<>(rsp.getEffectsList()), "%s", Set.of("Setpoint"), false, icon, null, null, null,
-                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
+                    Set.of("Setpoint"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            StateDescription stateDescription = addStateDescription(rsp.getEffectsList());
 
             Channel channel = ChannelBuilder
                     .create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId() + "-effects"))
@@ -148,7 +146,7 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
                     .withAcceptedItemType("String")
                     .withConfiguration(configuration(rsp.getKey(), CHANNEL_EFFECTS, "Light")).build();
 
-            super.registerChannel(channel, channelType);
+            super.registerChannel(channel, channelType, stateDescription);
 
         }
     }

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/LockMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/LockMessageHandler.java
@@ -12,7 +12,9 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.CommandDescription;
 import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,28 +48,31 @@ public class LockMessageHandler extends AbstractMessageHandler<ListEntitiesLockR
 
         String icon = getChannelIcon(rsp.getIcon(), "lock");
 
-        List<String> validOptions = new ArrayList<>();
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_LOCKED));
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_UNLOCKED));
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_JAMMED));
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_LOCKING));
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_UNLOCKING));
+        List<String> stateOptions = new ArrayList<>();
+        stateOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_LOCKED));
+        stateOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_UNLOCKED));
+        stateOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_JAMMED));
+        stateOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_LOCKING));
+        stateOptions.add(LockMessageHandler.stripEnumPrefix(LockState.LOCK_STATE_UNLOCKING));
 
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockCommand.LOCK_UNLOCK));
-        validOptions.add(LockMessageHandler.stripEnumPrefix(LockCommand.LOCK_LOCK));
+        List<String> commandOptions = new ArrayList<>();
+        commandOptions.add(LockMessageHandler.stripEnumPrefix(LockCommand.LOCK_UNLOCK));
+        commandOptions.add(LockMessageHandler.stripEnumPrefix(LockCommand.LOCK_LOCK));
 
         if (rsp.getSupportsOpen()) {
-            validOptions.add(stripEnumPrefix(LockCommand.LOCK_OPEN));
+            commandOptions.add(stripEnumPrefix(LockCommand.LOCK_OPEN));
         }
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "String", validOptions, null,
-                Set.of("Lock"), false, icon, null, null, null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "String", Set.of("Lock"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription(stateOptions);
+        CommandDescription commandDescription = addCommandDescription(commandOptions);
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType("String").withConfiguration(configuration).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription, commandDescription);
     }
 
     public void handleState(LockStateResponse rsp) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/LockMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/LockMessageHandler.java
@@ -11,11 +11,7 @@ import org.openhab.core.thing.ChannelUID;
 import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
-import org.openhab.core.types.Command;
-import org.openhab.core.types.CommandDescription;
-import org.openhab.core.types.State;
-import org.openhab.core.types.StateDescription;
-import org.openhab.core.types.UnDefType;
+import org.openhab.core.types.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,8 +61,8 @@ public class LockMessageHandler extends AbstractMessageHandler<ListEntitiesLockR
 
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "String", Set.of("Lock"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription(stateOptions);
-        CommandDescription commandDescription = addCommandDescription(commandOptions);
+        StateDescription stateDescription = optionListStateDescription(stateOptions);
+        CommandDescription commandDescription = optionListCommandDescription(commandOptions);
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/NumberMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/NumberMessageHandler.java
@@ -95,7 +95,7 @@ public class NumberMessageHandler extends AbstractMessageHandler<ListEntitiesNum
 
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, tags, icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription(
+        StateDescription stateDescription = numericStateDescription(
                 "%." + accurracyDecimals + "f " + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement),
                 rsp.getStep() != 0f ? BigDecimal.valueOf(rsp.getStep()) : null,
                 rsp.getMinValue() != 0f ? BigDecimal.valueOf(rsp.getMinValue()) : null,

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/NumberMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/NumberMessageHandler.java
@@ -1,7 +1,6 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
 import java.math.BigDecimal;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -16,6 +15,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.util.UnitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,17 +93,18 @@ public class NumberMessageHandler extends AbstractMessageHandler<ListEntitiesNum
 
         String icon = getChannelIcon(rsp.getIcon(), numberDeviceClass != null ? numberDeviceClass.getCategory() : null);
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptyList(),
-                "%." + accurracyDecimals + "f " + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement), tags,
-                false, icon, rsp.getStep() != 0f ? BigDecimal.valueOf(rsp.getStep()) : null,
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, tags, icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription(
+                "%." + accurracyDecimals + "f " + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement),
+                rsp.getStep() != 0f ? BigDecimal.valueOf(rsp.getStep()) : null,
                 rsp.getMinValue() != 0f ? BigDecimal.valueOf(rsp.getMinValue()) : null,
-                rsp.getMaxValue() != 0f ? BigDecimal.valueOf(rsp.getMaxValue()) : null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+                rsp.getMaxValue() != 0f ? BigDecimal.valueOf(rsp.getMaxValue()) : null);
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration).build();
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription);
     }
 
     @Override

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SelectMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SelectMessageHandler.java
@@ -36,7 +36,7 @@ public class SelectMessageHandler extends AbstractMessageHandler<ListEntitiesSel
 
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Setpoint"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription(rsp.getOptionsList());
+        StateDescription stateDescription = optionListStateDescription(rsp.getOptionsList());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SelectMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SelectMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.ArrayList;
 import java.util.Set;
 
 import org.openhab.core.library.types.StringType;
@@ -10,6 +9,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 
 import io.esphome.api.ListEntitiesSelectResponse;
@@ -34,15 +34,15 @@ public class SelectMessageHandler extends AbstractMessageHandler<ListEntitiesSel
 
         String icon = getChannelIcon(rsp.getIcon(), null);
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType,
-                new ArrayList<>(rsp.getOptionsList()), "%s", Set.of("Setpoint"), false, icon, null, null, null,
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Setpoint"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription(rsp.getOptionsList());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration(rsp.getKey(), null, "Select")).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription);
     }
 
     @Override

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
@@ -65,7 +65,7 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
             itemType = "DateTime";
             channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            stateDescription = addStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", true);
+            stateDescription = patternStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", true);
         } else {
             String unitOfMeasurement = rsp.getUnitOfMeasurement();
             itemType = resolveNumericItemType(unitOfMeasurement, rsp.getName(), sensorDeviceClass);
@@ -82,7 +82,7 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
 
             channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, tags, icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
-            stateDescription = addStateDescription("%." + rsp.getAccuracyDecimals() + "f "
+            stateDescription = patternStateDescription("%." + rsp.getAccuracyDecimals() + "f "
                     + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement), true);
         }
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -11,6 +10,7 @@ import org.openhab.core.thing.binding.builder.ChannelBuilder;
 import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.util.UnitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,12 +59,13 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
 
         String itemType;
         ChannelType channelType;
+        StateDescription stateDescription;
 
         if (sensorDeviceClass != null && "DateTime".equals(sensorDeviceClass.getItemType())) {
             itemType = "DateTime";
-            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptySet(),
-                    "%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", Set.of("Status"), true, icon, null, null, null,
+            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            stateDescription = addStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", true);
         } else {
             String unitOfMeasurement = rsp.getUnitOfMeasurement();
             itemType = resolveNumericItemType(unitOfMeasurement, rsp.getName(), sensorDeviceClass);
@@ -79,15 +80,15 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
                 }
             }
 
-            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptyList(),
-                    "%." + rsp.getAccuracyDecimals() + "f "
-                            + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement),
-                    tags, true, icon, null, null, null, rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, tags, icon,
+                    rsp.getEntityCategory(), rsp.getDisabledByDefault());
+            stateDescription = addStateDescription("%." + rsp.getAccuracyDecimals() + "f "
+                    + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement), true);
         }
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration).build();
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription);
     }
 
     private boolean isOHSupportedUnit(String unitOfMeasurement) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SwitchMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SwitchMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -34,9 +33,8 @@ public class SwitchMessageHandler extends AbstractMessageHandler<ListEntitiesSwi
 
         String icon = getChannelIcon(rsp.getIcon(), "switch");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Switch", Collections.emptySet(),
-                null, Set.of("Switch"), false, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), "Switch", Set.of("Switch"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -38,9 +37,8 @@ public class TextMessageHandler extends AbstractMessageHandler<ListEntitiesTextR
         String icon = getChannelIcon(rsp.getIcon(), "text");
 
         String itemType = "String";
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptySet(),
-                null, Set.of("Status"), false, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextSensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextSensorMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -45,15 +44,14 @@ public class TextSensorMessageHandler
         String icon = getChannelIcon(rsp.getIcon(), "text");
 
         String itemType = "String";
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptySet(),
-                null, Set.of("Status"), true, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, readOnlyStateDescription());
     }
 
     @Override

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TimeMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TimeMessageHandler.java
@@ -1,6 +1,5 @@
 package no.seime.openhab.binding.esphome.internal.message;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.openhab.core.config.core.Configuration;
@@ -13,6 +12,7 @@ import org.openhab.core.thing.type.ChannelKind;
 import org.openhab.core.thing.type.ChannelType;
 import org.openhab.core.types.Command;
 import org.openhab.core.types.State;
+import org.openhab.core.types.StateDescription;
 import org.openhab.core.types.UnDefType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,15 +48,15 @@ public class TimeMessageHandler extends AbstractMessageHandler<ListEntitiesTimeR
         String icon = getChannelIcon(rsp.getIcon(), "time");
 
         String itemType = "Number:Time";
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Collections.emptySet(),
-                "%1$tH:%1$tM:%1$tS", Set.of("Status"), false, icon, null, null, null, rsp.getEntityCategory(),
-                rsp.getDisabledByDefault());
+        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
+                rsp.getEntityCategory(), rsp.getDisabledByDefault());
+        StateDescription stateDescription = addStateDescription("%1$tH:%1$tM:%1$tS");
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())
                 .withAcceptedItemType(itemType).withConfiguration(configuration).build();
 
-        super.registerChannel(channel, channelType);
+        super.registerChannel(channel, channelType, stateDescription);
     }
 
     @Override

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TimeMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TimeMessageHandler.java
@@ -50,7 +50,7 @@ public class TimeMessageHandler extends AbstractMessageHandler<ListEntitiesTimeR
         String itemType = "Number:Time";
         ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
-        StateDescription stateDescription = addStateDescription("%1$tH:%1$tM:%1$tS");
+        StateDescription stateDescription = patternStateDescription("%1$tH:%1$tM:%1$tS");
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
                 .withLabel(rsp.getName()).withKind(ChannelKind.STATE).withType(channelType.getUID())

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/AbstractESPHomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/AbstractESPHomeDeviceTest.java
@@ -35,6 +35,7 @@ import no.seime.openhab.binding.esphome.internal.LogLevel;
 import no.seime.openhab.binding.esphome.internal.comm.ConnectionSelector;
 import no.seime.openhab.binding.esphome.internal.handler.ESPChannelTypeProvider;
 import no.seime.openhab.binding.esphome.internal.handler.ESPHomeHandler;
+import no.seime.openhab.binding.esphome.internal.handler.ESPStateDescriptionProvider;
 import no.seime.openhab.binding.esphome.internal.handler.MonitoredScheduledThreadPoolExecutor;
 import no.seime.openhab.binding.esphome.internal.message.statesubscription.ESPHomeEventSubscriber;
 
@@ -57,6 +58,7 @@ public abstract class AbstractESPHomeDeviceTest {
     private ConnectionSelector selector;
     private @Mock Configuration configuration;
     private @Mock ESPChannelTypeProvider channelTypeProvider;
+    private @Mock ESPStateDescriptionProvider stateDescriptionProvider;
     private ESPHomeDeviceRunner emulator;
 
     @BeforeEach
@@ -83,8 +85,8 @@ public abstract class AbstractESPHomeDeviceTest {
         when(itemRegistry.getItems()).thenReturn(registryItems);
         eventSubscriber = new ESPHomeEventSubscriber(thingRegistry, itemRegistry);
 
-        thingHandler = new ESPHomeHandler(thing, selector, channelTypeProvider, eventSubscriber, executor,
-                new KeySequentialExecutor(executor), null);
+        thingHandler = new ESPHomeHandler(thing, selector, channelTypeProvider, stateDescriptionProvider,
+                eventSubscriber, executor, new KeySequentialExecutor(executor), null);
         thingHandlerCallback = Mockito.mock(ThingHandlerCallback.class);
         thingHandler.setCallback(thingHandlerCallback);
     }


### PR DESCRIPTION
I had to use a DynamicStateDescriptionProvider instead of just putting the command description on the ChannelType, since I ran into JSON serialization issues with the AbstractStorageBasedTypeProvider trying to do it that way.

While there is an additional method call for most channels now, I feel like it actually makes the code clearer because there aren't sooo many (often unused) arguments to createChannelType.