### PR TITLE
Increase queue size warning threshold

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/MonitoredScheduledThreadPoolExecutor.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/MonitoredScheduledThreadPoolExecutor.java
@@ -19,7 +19,7 @@ public class MonitoredScheduledThreadPoolExecutor extends ScheduledThreadPoolExe
     }
 
     private void logQueue() {
-        if (getQueue().size() > 20)
+        if (getQueue().size() > 100)
             logger.warn(
                     "Queue size for processing packets from ESP device as well as maintaining the watchdog is high: {}",
                     getQueue().size());


### PR DESCRIPTION
If you have a LOT of ESPHome devices, you can be in a completely stable state, but this is spamming the log

I currently have 48 active devices, and was getting this warning about once per second in my log, with a queue depth of 53 every time.