### PR TITLE
Don't log for missing device class

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/BinarySensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/BinarySensorMessageHandler.java
@@ -49,8 +49,6 @@ public class BinarySensorMessageHandler
 
         BinarySensorDeviceClass binarySensorDeviceClass = BinarySensorDeviceClass.fromDeviceClass(deviceClass);
         if (binarySensorDeviceClass == null) {
-            logger.warn("[{}] Binary Sensor Device class `{}` unknown, using GENERIC for {}", handler.getLogPrefix(),
-                    deviceClass, rsp.getUniqueId());
             binarySensorDeviceClass = BinarySensorDeviceClass.GENERIC;
         }
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
@@ -167,11 +167,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
 
         CoverDeviceClass deviceClass = CoverDeviceClass.fromDeviceClass(rsp.getDeviceClass());
         if (deviceClass == null) {
-            logger.warn("[{}] Cover Device class `{}` unknown, using NONE for {}", handler.getLogPrefix(), deviceClass,
-                    rsp.getUniqueId());
-
             deviceClass = CoverDeviceClass.NONE;
-
         }
 
         String icon = getChannelIcon(rsp.getIcon(), deviceClass.getCategory());


### PR DESCRIPTION
It's perfectly normal. ESPHome doesn't care if you don't set it, and Home Assistant doesn't log any warnings, just uses a default none/generic just like this binding already does. It's extremely annoying to clog up logs with, especially at WARN level.