### PR TITLE
Chill with unknown unit of measurement log messages

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
@@ -289,10 +289,7 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
             if (unit != null) {
                 return new QuantityType<>(state, unit);
             } else {
-                logger.warn("[{}] Unit '{}' unknown to openHAB, returning DecimalType for state '{}' on channel '{}'",
-                        handler.getLogPrefix(), unitString, state, channel.getUID());
                 return new DecimalType(state);
-
             }
         } else {
             return new DecimalType(state);

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
@@ -74,7 +74,7 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
                 if (isOHSupportedUnit(unitOfMeasurement)) {
                     configuration.put("unit", unitOfMeasurement);
                 } else {
-                    logger.warn("[{}] Unit of measurement '{}' is not supported by openHAB, ignoring",
+                    logger.info("[{}] Unit of measurement '{}' is not supported by openHAB, ignoring",
                             handler.getLogPrefix(), unitOfMeasurement);
                     itemType = "Number";
                 }


### PR DESCRIPTION
 * We don't need to log at all every time a state is changed with a unit we don't recognize
 * When creating a channel with a unit we don't recognize, it should only be info level, since no functionality is affected