### PR TITLE
Fix channel type creating

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/AbstractMessageHandler.java
@@ -46,11 +46,11 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
         this.handler = handler;
     }
 
-    protected ChannelType addChannelType(final String channelTypePrefix, final String label, final String itemType,
+    protected ChannelType addChannelType(final String channelTypeSuffix, final String label, final String itemType,
             @Nullable final Set<String> tags, String category, EntityCategory entityCategory,
             boolean disabledByDefault) {
         final ChannelTypeUID channelTypeUID = new ChannelTypeUID(BindingConstants.BINDING_ID,
-                channelTypePrefix + handler.getThing().getUID().getId());
+                handler.getThing().getUID().getId() + "_" + channelTypeSuffix);
 
         final StateChannelTypeBuilder channelTypeBuilder = ChannelTypeBuilder.state(channelTypeUID, label, itemType);
         if (tags != null && !tags.isEmpty()) {
@@ -357,7 +357,7 @@ public abstract class AbstractMessageHandler<S extends GeneratedMessage, T exten
         }
         if (configuration != null)
             configuration.put("deviceClass", deviceClass.getDeviceClass());
-        return defaultDeviceClass;
+        return deviceClass;
     }
 
     protected Set<String> createSemanticTags(String point, DeviceClass deviceClass) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/BinarySensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/BinarySensorMessageHandler.java
@@ -59,7 +59,7 @@ public class BinarySensorMessageHandler
             tags.add("Status"); // default
         }
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), deviceClass.getItemType(), tags,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), deviceClass.getItemType(), tags,
                 icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/ButtonMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/ButtonMessageHandler.java
@@ -48,7 +48,7 @@ public class ButtonMessageHandler extends AbstractMessageHandler<ListEntitiesBut
 
         String icon = getChannelIcon(rsp.getIcon(), "switch");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), SWITCH, Set.of("Switch"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), SWITCH, Set.of("Switch"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/ClimateMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/ClimateMessageHandler.java
@@ -194,7 +194,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             addTargetTemperatureChannel(CHANNEL_TARGET_TEMPERATURE, "Target temperature", rsp);
         }
         if (rsp.getSupportsCurrentTemperature()) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_TEMPERATURE,
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_CURRENT_TEMPERATURE,
                     "Current temperature", ITEM_TYPE_TEMPERATURE, Set.of(SEMANTIC_TYPE_MEASUREMENT, "Temperature"),
                     "temperature", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = numericStateDescription("%.1f %unit%",
@@ -214,7 +214,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportsTargetHumidity()) {
-            ChannelType channelTypeTargetHumidity = addChannelType(rsp.getUniqueId() + CHANNEL_TARGET_HUMIDITY,
+            ChannelType channelTypeTargetHumidity = addChannelType(rsp.getObjectId() + CHANNEL_TARGET_HUMIDITY,
                     "Target humidity", ITEM_TYPE_NUMBER_DIMENSIONLESS, Set.of(SEMANTIC_TYPE_SETPOINT, "Humidity"),
                     "humidity", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = numericStateDescription("%.0f %unit%", null,
@@ -229,7 +229,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
         }
 
         if (rsp.getSupportsCurrentHumidity()) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_HUMIDITY, "Current humidity",
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_CURRENT_HUMIDITY, "Current humidity",
                     ITEM_TYPE_NUMBER_DIMENSIONLESS, Set.of(SEMANTIC_TYPE_MEASUREMENT, "Humidity"), "humidity",
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = patternStateDescription("%.0f %unit%", true);
@@ -242,7 +242,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
 
         String itemTypeString = "String";
         if (rsp.getSupportedModesCount() > 0) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_MODE, "Mode", itemTypeString,
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_MODE, "Mode", itemTypeString,
                     Set.of(SEMANTIC_TYPE_CONTROL), "climate", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedModesList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
@@ -253,7 +253,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportsAction()) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_ACTION, "Action", itemTypeString,
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_ACTION, "Action", itemTypeString,
                     Set.of(SEMANTIC_TYPE_STATUS), "climate", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(ACTIONS, true);
             Channel channel = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_ACTION))
@@ -263,7 +263,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportedFanModesCount() > 0) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_FAN_MODE, "Fan Mode", itemTypeString,
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_FAN_MODE, "Fan Mode", itemTypeString,
                     Set.of(SEMANTIC_TYPE_CONTROL, "Wind"), "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedFanModesList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
@@ -274,7 +274,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportedCustomFanModesCount() > 0) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CUSTOM_FAN_MODE, "Custom Fan Mode",
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_CUSTOM_FAN_MODE, "Custom Fan Mode",
                     itemTypeString, Set.of(SEMANTIC_TYPE_CONTROL, "Wind"), "fan", rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(rsp.getSupportedCustomFanModesList());
@@ -286,7 +286,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportedPresetsCount() > 0) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_PRESET, "Preset", itemTypeString,
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_PRESET, "Preset", itemTypeString,
                     Set.of(SEMANTIC_TYPE_CONTROL), "climate", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(
                     rsp.getSupportedPresetsList().stream().map(ClimateEnumHelper::stripEnumPrefix).toList());
@@ -297,7 +297,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportedCustomPresetsCount() > 0) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_CUSTOM_PRESET, "Custom Preset",
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_CUSTOM_PRESET, "Custom Preset",
                     itemTypeString, Set.of(SEMANTIC_TYPE_CONTROL), "climate", rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(rsp.getSupportedCustomPresetsList());
@@ -308,7 +308,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
             super.registerChannel(channel, channelType, stateDescription);
         }
         if (rsp.getSupportedSwingModesCount() > 0) {
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + CHANNEL_SWING_MODE, "Swing Mode",
+            ChannelType channelType = addChannelType(rsp.getObjectId() + CHANNEL_SWING_MODE, "Swing Mode",
                     itemTypeString, Set.of(SEMANTIC_TYPE_CONTROL, "Wind"), "fan", rsp.getEntityCategory(),
                     rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(
@@ -322,7 +322,7 @@ public class ClimateMessageHandler extends AbstractMessageHandler<ListEntitiesCl
     }
 
     private void addTargetTemperatureChannel(String channelID, String label, ListEntitiesClimateResponse rsp) {
-        ChannelType channelTypeTargetTemperature = addChannelType(rsp.getUniqueId() + channelID, label,
+        ChannelType channelTypeTargetTemperature = addChannelType(rsp.getObjectId() + channelID, label,
                 ITEM_TYPE_TEMPERATURE, Set.of(SEMANTIC_TYPE_SETPOINT, "Temperature"), "temperature",
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         StateDescription stateDescription = numericStateDescription("%.1f %unit%",

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/CoverMessageHandler.java
@@ -179,7 +179,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
         if (rsp.getSupportsPosition()) {
             Set<String> semanticTags = createSemanticTags("OpenLevel", deviceClass);
 
-            ChannelType channelTypePosition = addChannelType(rsp.getUniqueId() + CHANNEL_POSITION, "Position",
+            ChannelType channelTypePosition = addChannelType(rsp.getObjectId() + CHANNEL_POSITION, "Position",
                     deviceClass.getItemType(), semanticTags, icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = patternStateDescription("%d %%");
 
@@ -192,7 +192,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
         if (rsp.getSupportsTilt()) {
             Set<String> semanticTags = createSemanticTags("Tilt", deviceClass);
 
-            ChannelType channelTypeTilt = addChannelType(rsp.getUniqueId() + CHANNEL_TILT, "Tilt",
+            ChannelType channelTypeTilt = addChannelType(rsp.getObjectId() + CHANNEL_TILT, "Tilt",
                     deviceClass.getItemType(), semanticTags, icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = patternStateDescription("%d %%");
 
@@ -205,7 +205,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
 
         // Legacy state
 
-        ChannelType channelTypeState = addChannelType(rsp.getUniqueId() + LEGACY_CHANNEL_STATE, "Legacy State",
+        ChannelType channelTypeState = addChannelType(rsp.getObjectId() + LEGACY_CHANNEL_STATE, "Legacy State",
                 deviceClass.getItemType(), createSemanticTags("OpenClose", deviceClass), icon, rsp.getEntityCategory(),
                 rsp.getDisabledByDefault());
         StateDescription stateDescription = patternStateDescription("%s");
@@ -217,7 +217,7 @@ public class CoverMessageHandler extends AbstractMessageHandler<ListEntitiesCove
         super.registerChannel(channelState, channelTypeState, stateDescription);
 
         // Operation status
-        ChannelType channelTypeCurrentOperation = addChannelType(rsp.getUniqueId() + CHANNEL_CURRENT_OPERATION,
+        ChannelType channelTypeCurrentOperation = addChannelType(rsp.getObjectId() + CHANNEL_CURRENT_OPERATION,
                 "Current operation", STRING, createSemanticTags("Status", deviceClass), "motion",
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         stateDescription = optionListStateDescription(Set.of("IDLE", "IS_OPENING", "IS_CLOSING"), true);

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateMessageHandler.java
@@ -52,7 +52,7 @@ public class DateMessageHandler extends AbstractMessageHandler<ListEntitiesDateR
 
         String icon = getChannelIcon(rsp.getIcon(), "time");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), DATETIME, Set.of("Control"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), DATETIME, Set.of("Control"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         StateDescription stateDescription = patternStateDescription("%1$tY-%1$tm-%1$td");
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateTimeMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/DateTimeMessageHandler.java
@@ -51,7 +51,7 @@ public class DateTimeMessageHandler
 
         String icon = getChannelIcon(rsp.getIcon(), "time");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), DATETIME, Set.of("Control"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), DATETIME, Set.of("Control"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         StateDescription stateDescription = patternStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS");
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/FanMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/FanMessageHandler.java
@@ -189,7 +189,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
 
         String icon = getChannelIcon(rsp.getIcon(), "fan");
 
-        ChannelType channelTypeState = addChannelType(rsp.getUniqueId() + CHANNEL_STATE, "State", SWITCH,
+        ChannelType channelTypeState = addChannelType(rsp.getObjectId() + CHANNEL_STATE, "State", SWITCH,
                 Set.of("Switch"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channelState = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_STATE))
@@ -200,7 +200,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
         super.registerChannel(channelState, channelTypeState);
 
         if (rsp.getSupportsOscillation()) {
-            ChannelType channelTypeOscillation = addChannelType(rsp.getUniqueId() + CHANNEL_OSCILLATION, "Oscillation",
+            ChannelType channelTypeOscillation = addChannelType(rsp.getObjectId() + CHANNEL_OSCILLATION, "Oscillation",
                     SWITCH, Set.of("Control"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channelOscillation = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_OSCILLATION))
@@ -212,7 +212,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
         }
         if (rsp.getSupportsDirection()) {
 
-            ChannelType channelTypeDirection = addChannelType(rsp.getUniqueId() + CHANNEL_DIRECTION, "Direction",
+            ChannelType channelTypeDirection = addChannelType(rsp.getObjectId() + CHANNEL_DIRECTION, "Direction",
                     STRING, Set.of("Control"), "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(
                     Arrays.stream(FanDirection.values()).filter(e -> e != FanDirection.UNRECOGNIZED)
@@ -230,7 +230,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
 
             int supportedSpeedLevels = rsp.getSupportedSpeedCount();
 
-            ChannelType channelTypeSpeed = addChannelType(rsp.getUniqueId() + CHANNEL_SPEED_LEVEL, "Speed", DIMMER,
+            ChannelType channelTypeSpeed = addChannelType(rsp.getObjectId() + CHANNEL_SPEED_LEVEL, "Speed", DIMMER,
                     Set.of("Setpoint", "Speed"), icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = numericStateDescription(null,
                     BigDecimal.valueOf(100 / supportedSpeedLevels), BigDecimal.ZERO, BigDecimal.valueOf(100));
@@ -244,7 +244,7 @@ public class FanMessageHandler extends AbstractMessageHandler<ListEntitiesFanRes
         }
 
         if (rsp.getSupportedPresetModesCount() > 0) {
-            ChannelType channelTypePreset = addChannelType(rsp.getUniqueId() + CHANNEL_PRESET, "Preset", STRING,
+            ChannelType channelTypePreset = addChannelType(rsp.getObjectId() + CHANNEL_PRESET, "Preset", STRING,
                     Set.of("Setpoint"), "fan", rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(rsp.getSupportedPresetModesList());
             Channel channelPreset = ChannelBuilder.create(createChannelUID(rsp.getObjectId(), CHANNEL_PRESET))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/LightMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/LightMessageHandler.java
@@ -112,7 +112,7 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
         Set<String> semanticTags = Set.of("Control", "Light");
         if (capabilities.contains(LightColorCapability.RGB)) {
             // Go for a single Color channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), COLOR, semanticTags, icon,
+            ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), COLOR, semanticTags, icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
@@ -122,7 +122,7 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
             super.registerChannel(channel, channelType);
         } else if (capabilities.contains(LightColorCapability.BRIGHTNESS)) {
             // Go for a single Dimmer channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), DIMMER, semanticTags, icon,
+            ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), DIMMER, semanticTags, icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
@@ -132,7 +132,7 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
             super.registerChannel(channel, channelType);
         } else if (capabilities.contains(LightColorCapability.ON_OFF)) {
             // Go for a single Switch channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), SWITCH, semanticTags, icon,
+            ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), SWITCH, semanticTags, icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
             Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))
@@ -144,7 +144,7 @@ public class LightMessageHandler extends AbstractMessageHandler<ListEntitiesLigh
 
         if (rsp.getEffectsCount() > 0) {
             // Create effects channel
-            ChannelType channelType = addChannelType(rsp.getUniqueId() + "-effects", rsp.getName(), STRING,
+            ChannelType channelType = addChannelType(rsp.getObjectId() + "-effects", rsp.getName(), STRING,
                     semanticTags, icon, rsp.getEntityCategory(), rsp.getDisabledByDefault());
             StateDescription stateDescription = optionListStateDescription(rsp.getEffectsList());
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/LockMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/LockMessageHandler.java
@@ -62,7 +62,7 @@ public class LockMessageHandler extends AbstractMessageHandler<ListEntitiesLockR
             commandOptions.add(stripEnumPrefix(LockCommand.LOCK_OPEN));
         }
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), STRING, Set.of("Switch"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), STRING, Set.of("Switch"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         StateDescription stateDescription = optionListStateDescription(stateOptions);
         CommandDescription commandDescription = optionListCommandDescription(commandOptions);

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/NumberMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/NumberMessageHandler.java
@@ -83,7 +83,7 @@ public class NumberMessageHandler extends AbstractMessageHandler<ListEntitiesNum
 
         String icon = getChannelIcon(rsp.getIcon(), deviceClass.getCategory());
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, semanticTags, icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), itemType, semanticTags, icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         StateDescription stateDescription = numericStateDescription(

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SelectMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SelectMessageHandler.java
@@ -36,7 +36,7 @@ public class SelectMessageHandler extends AbstractMessageHandler<ListEntitiesSel
 
         String icon = getChannelIcon(rsp.getIcon(), null);
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), STRING, Set.of("Control"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), STRING, Set.of("Control"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         StateDescription stateDescription = optionListStateDescription(rsp.getOptionsList());
 

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SensorMessageHandler.java
@@ -53,11 +53,11 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
         StateDescription stateDescription;
 
         if (deviceClass.getItemType().equals(DATETIME)) {
-            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
+            channelType = addChannelType(rsp.getObjectId(), rsp.getName(), itemType, Set.of("Status"), icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
             stateDescription = patternStateDescription("%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS", true);
         } else if (deviceClass.getItemType().equals(STRING)) {
-            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Status"), icon,
+            channelType = addChannelType(rsp.getObjectId(), rsp.getName(), itemType, Set.of("Status"), icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
             stateDescription = patternStateDescription("%s", true);
         } else {
@@ -75,7 +75,7 @@ public class SensorMessageHandler extends AbstractMessageHandler<ListEntitiesSen
                 }
             }
 
-            channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, semanticTags, icon,
+            channelType = addChannelType(rsp.getObjectId(), rsp.getName(), itemType, semanticTags, icon,
                     rsp.getEntityCategory(), rsp.getDisabledByDefault());
             stateDescription = patternStateDescription("%." + rsp.getAccuracyDecimals() + "f "
                     + (unitOfMeasurement.equals("%") ? "%unit%" : unitOfMeasurement), true);

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/SwitchMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/SwitchMessageHandler.java
@@ -36,7 +36,7 @@ public class SwitchMessageHandler extends AbstractMessageHandler<ListEntitiesSwi
 
         String icon = getChannelIcon(rsp.getIcon(), "switch");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), SWITCH, Set.of("Switch"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), SWITCH, Set.of("Switch"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextMessageHandler.java
@@ -39,7 +39,7 @@ public class TextMessageHandler extends AbstractMessageHandler<ListEntitiesTextR
 
         String icon = getChannelIcon(rsp.getIcon(), "text");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), STRING, Set.of("Status"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), STRING, Set.of("Status"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextSensorMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TextSensorMessageHandler.java
@@ -46,7 +46,7 @@ public class TextSensorMessageHandler
 
         String icon = getChannelIcon(rsp.getIcon(), "text");
 
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), STRING, Set.of("Status"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), STRING, Set.of("Status"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
 
         Channel channel = ChannelBuilder.create(new ChannelUID(handler.getThing().getUID(), rsp.getObjectId()))

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/message/TimeMessageHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/message/TimeMessageHandler.java
@@ -49,7 +49,7 @@ public class TimeMessageHandler extends AbstractMessageHandler<ListEntitiesTimeR
         String icon = getChannelIcon(rsp.getIcon(), "time");
 
         String itemType = "Number:Time";
-        ChannelType channelType = addChannelType(rsp.getUniqueId(), rsp.getName(), itemType, Set.of("Control"), icon,
+        ChannelType channelType = addChannelType(rsp.getObjectId(), rsp.getName(), itemType, Set.of("Control"), icon,
                 rsp.getEntityCategory(), rsp.getDisabledByDefault());
         StateDescription stateDescription = patternStateDescription("%1$tH:%1$tM:%1$tS");
 

--- a/src/main/proto/api.proto
+++ b/src/main/proto/api.proto
@@ -274,7 +274,7 @@ message ListEntitiesBinarySensorResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string device_class = 5;
   bool is_status_binary_sensor = 6;
@@ -306,7 +306,7 @@ message ListEntitiesCoverResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   bool assumed_state = 5;
   bool supports_position = 6;
@@ -379,7 +379,7 @@ message ListEntitiesFanResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   bool supports_oscillation = 5;
   bool supports_speed = 6;
@@ -458,7 +458,7 @@ message ListEntitiesLightResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   repeated ColorMode supported_color_modes = 12;
   // next four supports_* are for legacy clients, newer clients should use color modes
@@ -552,7 +552,7 @@ message ListEntitiesSensorResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   string unit_of_measurement = 6;
@@ -589,7 +589,7 @@ message ListEntitiesSwitchResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool assumed_state = 6;
@@ -627,7 +627,7 @@ message ListEntitiesTextSensorResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -811,7 +811,7 @@ message ListEntitiesCameraResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
   bool disabled_by_default = 5;
   string icon = 6;
   EntityCategory entity_category = 7;
@@ -892,7 +892,7 @@ message ListEntitiesClimateResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   bool supports_current_temperature = 5;
   bool supports_two_point_target_temperature = 6;
@@ -989,7 +989,7 @@ message ListEntitiesNumberResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   float min_value = 6;
@@ -1034,7 +1034,7 @@ message ListEntitiesSelectResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   repeated string options = 6;
@@ -1074,7 +1074,7 @@ message ListEntitiesSirenResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1133,7 +1133,7 @@ message ListEntitiesLockResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1178,7 +1178,7 @@ message ListEntitiesButtonResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1230,7 +1230,7 @@ message ListEntitiesMediaPlayerResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1771,7 +1771,7 @@ message ListEntitiesAlarmControlPanelResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
   string icon = 5;
   bool disabled_by_default = 6;
   EntityCategory entity_category = 7;
@@ -1814,7 +1814,7 @@ message ListEntitiesTextResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
   string icon = 5;
   bool disabled_by_default = 6;
   EntityCategory entity_category = 7;
@@ -1858,7 +1858,7 @@ message ListEntitiesDateResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1901,7 +1901,7 @@ message ListEntitiesTimeResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1944,7 +1944,7 @@ message ListEntitiesEventResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -1972,7 +1972,7 @@ message ListEntitiesValveResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -2023,7 +2023,7 @@ message ListEntitiesDateTimeResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;
@@ -2062,7 +2062,7 @@ message ListEntitiesUpdateResponse {
   string object_id = 1;
   fixed32 key = 2;
   string name = 3;
-  string unique_id = 4;
+  reserved 4; // Deprecated: was string unique_id
 
   string icon = 5;
   bool disabled_by_default = 6;


### PR DESCRIPTION
1. Fix resolving deviceСlass - always returned the defaultDeviceClass
2. Fix api.proto - uniqueId is deprecated and was removed in the [v36.0.0](https://github.com/esphome/aioesphomeapi/releases/tag/v36.0.0) aioesphomeapi
3. And as a result of point 2 - сhange ChannelTypeUID naming to next format: ThingId_ObjectId
