### PR TITLE
Avoid logging warning about ConnectResponse that is a success

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -412,8 +412,8 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                 logger.debug("[{}] Received login response {}", logPrefix, connectResponse);
 
                 handleDisconnection(ThingStatusDetail.CONFIGURATION_ERROR, "Invalid password", false);
-                return;
             }
+            return;
         }
 
         if (message instanceof DeviceInfoResponse rsp) {


### PR DESCRIPTION
It might still be sent by older devices.