### PR TITLE
Fix IllegalStateException on dynamic action reload

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/action/DynamicThingActionsGenerator.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/action/DynamicThingActionsGenerator.java
@@ -53,6 +53,16 @@ public class DynamicThingActionsGenerator {
         String className = String.format("no.seime.openhab.binding.esphome.internal.handler.action.%s",
                 classNameAsString);
 
+        // Check if the class was already loaded (e.g. from a previous connection)
+        try {
+            @SuppressWarnings("unchecked")
+            final Class<? extends AbstractESPHomeThingAction> existingClass = (Class<? extends AbstractESPHomeThingAction>) thingActionClassLoader
+                    .loadClass(className);
+            return existingClass.getDeclaredConstructor().newInstance();
+        } catch (ClassNotFoundException e) {
+            // fall through
+        }
+
         DynamicType.Builder<AbstractESPHomeThingAction> thingActionType = new ByteBuddy()
                 .subclass(AbstractESPHomeThingAction.class).name(className).annotateType(componentAnnotation)
                 .annotateType(thingScopeAction);

--- a/src/test/java/no/seime/openhab/binding/esphome/internal/handler/action/DynamicThingActionsGeneratorTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/internal/handler/action/DynamicThingActionsGeneratorTest.java
@@ -1,0 +1,35 @@
+package no.seime.openhab.binding.esphome.internal.handler.action;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import io.esphome.api.ListEntitiesServicesArgument;
+import io.esphome.api.ListEntitiesServicesResponse;
+import io.esphome.api.ServiceArgType;
+
+public class DynamicThingActionsGeneratorTest {
+
+    @Test
+    public void testGenerateTwiceReturnsCachedClass() throws Exception {
+        final ListEntitiesServicesResponse rsp = ListEntitiesServicesResponse.newBuilder().setKey(1)
+                .setName("play_buzzer").addArgs(ListEntitiesServicesArgument.newBuilder().setName("duration")
+                        .setTypeValue(ServiceArgType.SERVICE_ARG_TYPE_INT_VALUE).build())
+                .build();
+
+        final ClassLoader classLoader = getClass().getClassLoader();
+
+        final AbstractESPHomeThingAction first = DynamicThingActionsGenerator.generateDynamicThingAction(rsp,
+                classLoader);
+        assertNotNull(first);
+        assertInstanceOf(AbstractESPHomeThingAction.class, first);
+
+        final AbstractESPHomeThingAction second = assertDoesNotThrow(
+                () -> DynamicThingActionsGenerator.generateDynamicThingAction(rsp, classLoader));
+        assertNotNull(second);
+        assertSame(first.getClass(), second.getClass());
+    }
+}


### PR DESCRIPTION
## Summary
- On device reconnect, `DynamicThingActionsGenerator` attempted to inject a ByteBuddy-generated class that was already loaded into the classloader, causing `IllegalStateException: Cannot inject already loaded type`
- Fix checks if the class already exists in the classloader before attempting ByteBuddy generation, reusing it if present
- Added unit test verifying that calling `generateDynamicThingAction` twice with the same service name doesn't throw

## Test plan
- [x] Unit test `DynamicThingActionsGeneratorTest.testGenerateTwiceReturnsCachedClass` passes
- [x] Verify on a real device that reconnection no longer produces the stacktrace

🤖 Generated with [Claude Code](https://claude.com/claude-code)