### PR TITLE
Cache last known IP address

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -715,8 +715,9 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             return new ResolvedConnectionTarget(resolvedAddress.getHostAddress(), resolvedAddress.getHostAddress(),
                     configuredHostname, configuredHostname, true);
         } catch (UnknownHostException e) {
-            String lastKnownIpAddress = thing.getProperties().get(PROPERTY_LAST_KNOWN_IP_ADDRESS);
-            if (lastKnownIpAddress != null && !lastKnownIpAddress.isEmpty()) {
+            String lastKnownIpAddress = StringUtils
+                    .trimToNull(thing.getProperties().get(PROPERTY_LAST_KNOWN_IP_ADDRESS));
+            if (lastKnownIpAddress != null && InetAddresses.isInetAddress(lastKnownIpAddress)) {
                 logger.warn("[{}] Failed to resolve '{}'. Falling back to cached IP {}", logPrefix, configuredHostname,
                         lastKnownIpAddress);
                 return new ResolvedConnectionTarget(lastKnownIpAddress, lastKnownIpAddress,

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -13,6 +13,8 @@
 package no.seime.openhab.binding.esphome.internal.handler;
 
 import java.math.BigDecimal;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ScheduledFuture;
@@ -34,6 +36,7 @@ import org.osgi.framework.ServiceRegistration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.net.InetAddresses;
 import com.google.protobuf.GeneratedMessage;
 import com.jano7.executor.KeySequentialExecutor;
 
@@ -62,6 +65,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     private static final int API_VERSION_MINOR = 9;
     private static final String DEVICE_LOGGER_NAME = "ESPHOMEDEVICE";
     private static final String ACTION_TAG_SCANNED = "esphome.tag_scanned";
+    static final String PROPERTY_LAST_KNOWN_IP_ADDRESS = "lastKnownIpAddress";
 
     private final Logger logger = LoggerFactory.getLogger(ESPHomeHandler.class);
     private final Logger deviceLogger = LoggerFactory.getLogger(DEVICE_LOGGER_NAME);
@@ -95,6 +99,8 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     private boolean bluetoothProxyStarted = false;
     // default is not used initialized in initialize()
     private ExponentialBackoff exponentialBackoff = new ExponentialBackoff(10, 500);
+    @Nullable
+    private String resolvedIpAddressForCurrentConnection;
 
     private final Set<ServiceRegistration<?>> thingActionServiceRegistrations = new HashSet<>();
 
@@ -244,10 +250,15 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
 
                 String hostname = config.hostname;
                 int port = config.port;
+                ResolvedConnectionTarget connectionTarget = resolveConnectionTarget(hostname);
+                resolvedIpAddressForCurrentConnection = connectionTarget.cacheLastKnownIpAddress
+                        ? connectionTarget.ipAddress
+                        : null;
+                applyLastKnownIpAddressPolicy(connectionTarget);
 
-                logger.info("[{}] Trying to connect to {}:{}", logPrefix, hostname, port);
+                logger.info("[{}] Trying to connect to {}:{}", logPrefix, connectionTarget.logTarget(), port);
                 updateStatus(ThingStatus.UNKNOWN, ThingStatusDetail.NONE,
-                        String.format("Connecting to %s:%d", hostname, port));
+                        String.format("Connecting to %s:%d", connectionTarget.statusTarget(), port));
 
                 // Default to using the default encryption key from the binding if not set in device configuration
                 String encryptionKey = config.encryptionKey;
@@ -267,7 +278,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                 frameHelper = new EncryptedFrameHelper(connectionSelector, this, encryptionKey, config.deviceId,
                         logPrefix, packetProcessor);
 
-                frameHelper.connect(hostname, port);
+                frameHelper.connect(connectionTarget.connectHost, port);
 
                 cancelConnectionTimeoutWatchdog();
                 connectionTimeoutFuture = executorService.schedule(() -> {
@@ -280,6 +291,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                 logger.warn("[{}] Error initial connection", logPrefix, e);
                 updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, e.getMessage());
                 connectionState = ConnectionState.UNINITIALIZED;
+                resolvedIpAddressForCurrentConnection = null;
                 scheduleConnect(exponentialBackoff.getNextDelay());
             }
         }
@@ -421,6 +433,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             }
 
             connectionState = ConnectionState.UNINITIALIZED;
+            resolvedIpAddressForCurrentConnection = null;
 
             if (scheduleReconnect) {
                 scheduleConnect(nextDelay);
@@ -448,7 +461,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
         }
 
         if (message instanceof DeviceInfoResponse rsp) {
-            Map<String, String> props = new HashMap<>();
+            Map<String, String> props = new HashMap<>(thing.getProperties());
             props.put(Thing.PROPERTY_FIRMWARE_VERSION, rsp.getEsphomeVersion());
             props.put(Thing.PROPERTY_MAC_ADDRESS, rsp.getMacAddress());
             props.put(Thing.PROPERTY_MODEL_ID, rsp.getModel());
@@ -457,9 +470,13 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             props.put("compilationTime", rsp.getCompilationTime());
             if (!rsp.getProjectName().isEmpty()) {
                 props.put("projectName", rsp.getProjectName());
+            } else {
+                props.remove("projectName");
             }
             if (!rsp.getProjectVersion().isEmpty()) {
                 props.put("projectVersion", rsp.getProjectVersion());
+            } else {
+                props.remove("projectVersion");
             }
             updateThing(editThing().withProperties(props).build());
         } else if (message instanceof ListEntitiesDoneResponse) {
@@ -620,6 +637,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                         logPrefix, helloResponse.getName(), helloResponse.getServerInfo(),
                         helloResponse.getApiVersionMajor(), helloResponse.getApiVersionMinor());
                 connectionState = ConnectionState.CONNECTED;
+                persistLastKnownIpAddress();
 
                 if (config.allowActions) {
                     logger.debug("[{}] Requesting device to send actions and events", logPrefix);
@@ -682,6 +700,63 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                 frameHelper.send(SubscribeHomeAssistantStatesRequest.getDefaultInstance());
             }
         }
+    }
+
+    private ResolvedConnectionTarget resolveConnectionTarget(String configuredHostname) throws ProtocolAPIError {
+        if (InetAddresses.isInetAddress(configuredHostname)) {
+            InetAddress configuredAddress = InetAddresses.forString(configuredHostname);
+            String configuredIpAddress = configuredAddress.getHostAddress();
+            return new ResolvedConnectionTarget(configuredIpAddress, configuredIpAddress, configuredHostname,
+                    configuredHostname, false);
+        }
+
+        try {
+            InetAddress resolvedAddress = InetAddress.getByName(configuredHostname);
+            return new ResolvedConnectionTarget(resolvedAddress.getHostAddress(), resolvedAddress.getHostAddress(),
+                    configuredHostname, configuredHostname, true);
+        } catch (UnknownHostException e) {
+            String lastKnownIpAddress = thing.getProperties().get(PROPERTY_LAST_KNOWN_IP_ADDRESS);
+            if (StringUtils.isNotBlank(lastKnownIpAddress)) {
+                logger.warn("[{}] Failed to resolve '{}'. Falling back to cached IP {}", logPrefix, configuredHostname,
+                        lastKnownIpAddress);
+                return new ResolvedConnectionTarget(lastKnownIpAddress, lastKnownIpAddress,
+                        configuredHostname + " (cached " + lastKnownIpAddress + ")", lastKnownIpAddress, true);
+            }
+            throw new ProtocolAPIError("Failed to resolve hostname '" + configuredHostname + "'", e);
+        }
+    }
+
+    private void applyLastKnownIpAddressPolicy(ResolvedConnectionTarget connectionTarget) {
+        if (connectionTarget.cacheLastKnownIpAddress) {
+            return;
+        }
+        removeLastKnownIpAddressProperty();
+    }
+
+    private void persistLastKnownIpAddress() {
+        String ipAddress = resolvedIpAddressForCurrentConnection;
+        if (StringUtils.isBlank(ipAddress)
+                || ipAddress.equals(thing.getProperties().get(PROPERTY_LAST_KNOWN_IP_ADDRESS))) {
+            return;
+        }
+
+        Map<String, String> props = new HashMap<>(thing.getProperties());
+        props.put(PROPERTY_LAST_KNOWN_IP_ADDRESS, ipAddress);
+        updateThing(editThing().withProperties(props).build());
+    }
+
+    private void removeLastKnownIpAddressProperty() {
+        if (!thing.getProperties().containsKey(PROPERTY_LAST_KNOWN_IP_ADDRESS)) {
+            return;
+        }
+
+        Map<String, String> props = new HashMap<>(thing.getProperties());
+        props.remove(PROPERTY_LAST_KNOWN_IP_ADDRESS);
+        updateThing(editThing().withProperties(props).build());
+    }
+
+    private record ResolvedConnectionTarget(String connectHost, String ipAddress, String logTarget, String statusTarget,
+            boolean cacheLastKnownIpAddress) {
     }
 
     public void addChannelType(ChannelType channelType) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -716,7 +716,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                     configuredHostname, configuredHostname, true);
         } catch (UnknownHostException e) {
             String lastKnownIpAddress = thing.getProperties().get(PROPERTY_LAST_KNOWN_IP_ADDRESS);
-            if (StringUtils.isNotBlank(lastKnownIpAddress)) {
+            if (lastKnownIpAddress != null && !lastKnownIpAddress.isEmpty()) {
                 logger.warn("[{}] Failed to resolve '{}'. Falling back to cached IP {}", logPrefix, configuredHostname,
                         lastKnownIpAddress);
                 return new ResolvedConnectionTarget(lastKnownIpAddress, lastKnownIpAddress,

--- a/src/test/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerLastKnownIpAddressTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerLastKnownIpAddressTest.java
@@ -83,7 +83,30 @@ class ESPHomeHandlerLastKnownIpAddressTest {
     }
 
     @Test
+    void fallsBackToTrimmedCachedIpAddressWhenHostnameResolutionFails() throws Exception {
+        thing.setProperties(Map.of(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS, " 127.0.0.1 "));
+
+        Object target = invokeMethod("resolveConnectionTarget", new Class<?>[] { String.class }, "device.invalid");
+
+        assertEquals("127.0.0.1", invokeRecordAccessor(target, "connectHost"));
+        assertEquals("127.0.0.1", invokeRecordAccessor(target, "ipAddress"));
+    }
+
+    @Test
     void throwsWhenHostnameResolutionFailsWithoutCachedIpAddress() {
+        Exception error = assertThrows(Exception.class,
+                () -> invokeMethod("resolveConnectionTarget", new Class<?>[] { String.class }, "device.invalid"));
+
+        Throwable cause = error.getCause();
+        assertNotNull(cause);
+        assertInstanceOf(ProtocolAPIError.class, cause);
+        assertEquals("Failed to resolve hostname 'device.invalid'", cause.getMessage());
+    }
+
+    @Test
+    void throwsWhenHostnameResolutionFailsWithInvalidCachedIpAddress() {
+        thing.setProperties(Map.of(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS, " not-an-ip "));
+
         Exception error = assertThrows(Exception.class,
                 () -> invokeMethod("resolveConnectionTarget", new Class<?>[] { String.class }, "device.invalid"));
 

--- a/src/test/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerLastKnownIpAddressTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerLastKnownIpAddressTest.java
@@ -1,0 +1,163 @@
+package no.seime.openhab.binding.esphome.internal.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openhab.core.events.EventPublisher;
+import org.openhab.core.thing.binding.ThingHandlerCallback;
+import org.openhab.core.thing.internal.ThingImpl;
+import org.osgi.framework.BundleContext;
+
+import com.jano7.executor.KeySequentialExecutor;
+
+import io.esphome.api.DeviceInfoResponse;
+import no.seime.openhab.binding.esphome.internal.BindingConstants;
+import no.seime.openhab.binding.esphome.internal.comm.ConnectionSelector;
+import no.seime.openhab.binding.esphome.internal.comm.ProtocolAPIError;
+import no.seime.openhab.binding.esphome.internal.message.statesubscription.ESPHomeEventSubscriber;
+
+@ExtendWith(MockitoExtension.class)
+class ESPHomeHandlerLastKnownIpAddressTest {
+
+    @Mock
+    private ESPChannelTypeProvider channelTypeProvider;
+    @Mock
+    private ESPStateDescriptionProvider stateDescriptionProvider;
+    @Mock
+    private ESPHomeEventSubscriber eventSubscriber;
+    @Mock
+    private EventPublisher eventPublisher;
+    @Mock
+    private BundleContext bundleContext;
+    @Mock
+    private ThingHandlerCallback callback;
+
+    private ESPHomeHandler handler;
+    private ThingImpl thing;
+    private MonitoredScheduledThreadPoolExecutor executor;
+    private ExecutorService packetProcessorExecutor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        thing = new ThingImpl(BindingConstants.THING_TYPE_DEVICE, "device");
+        executor = new MonitoredScheduledThreadPoolExecutor(1, Executors.defaultThreadFactory(), 1000);
+        packetProcessorExecutor = Executors.newSingleThreadExecutor();
+        handler = new ESPHomeHandler(thing, new ConnectionSelector(), channelTypeProvider, stateDescriptionProvider,
+                eventSubscriber, executor, new KeySequentialExecutor(packetProcessorExecutor), eventPublisher, null,
+                bundleContext);
+        handler.setCallback(callback);
+    }
+
+    @AfterEach
+    void tearDown() {
+        handler.dispose();
+        executor.shutdownNow();
+        packetProcessorExecutor.shutdownNow();
+    }
+
+    @Test
+    void fallsBackToCachedIpAddressWhenHostnameResolutionFails() throws Exception {
+        thing.setProperties(Map.of(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS, "127.0.0.1"));
+
+        Object target = invokeMethod("resolveConnectionTarget", new Class<?>[] { String.class }, "device.invalid");
+
+        assertEquals("127.0.0.1", invokeRecordAccessor(target, "connectHost"));
+        assertEquals("127.0.0.1", invokeRecordAccessor(target, "ipAddress"));
+    }
+
+    @Test
+    void throwsWhenHostnameResolutionFailsWithoutCachedIpAddress() {
+        Exception error = assertThrows(Exception.class,
+                () -> invokeMethod("resolveConnectionTarget", new Class<?>[] { String.class }, "device.invalid"));
+
+        Throwable cause = error.getCause();
+        assertNotNull(cause);
+        assertInstanceOf(ProtocolAPIError.class, cause);
+        assertEquals("Failed to resolve hostname 'device.invalid'", cause.getMessage());
+    }
+
+    @Test
+    void doesNotUseCachedIpAddressWhenConfiguredHostnameIsLiteralIp() throws Exception {
+        thing.setProperties(Map.of(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS, "127.0.0.1"));
+
+        Object target = invokeMethod("resolveConnectionTarget", new Class<?>[] { String.class }, "192.0.2.55");
+
+        assertEquals("192.0.2.55", invokeRecordAccessor(target, "connectHost"));
+        assertEquals("192.0.2.55", invokeRecordAccessor(target, "ipAddress"));
+        assertEquals(false, invokeRecordAccessor(target, "cacheLastKnownIpAddress"));
+
+        invokeMethod("applyLastKnownIpAddressPolicy", new Class<?>[] { target.getClass() }, target);
+
+        verify(callback).thingUpdated(argThat(updatedThing -> !updatedThing.getProperties()
+                .containsKey(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS)));
+    }
+
+    @Test
+    void persistsResolvedIpAddressOnThingUpdate() throws Exception {
+        setField("resolvedIpAddressForCurrentConnection", "127.0.0.1");
+
+        invokeMethod("persistLastKnownIpAddress", new Class<?>[0]);
+
+        verify(callback).thingUpdated(argThat(updatedThing -> "127.0.0.1"
+                .equals(updatedThing.getProperties().get(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS))));
+    }
+
+    @Test
+    void doesNotPersistResolvedIpAddressWhenLiteralIpModeIsActive() throws Exception {
+        thing.setProperties(Map.of(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS, "127.0.0.1"));
+        setField("resolvedIpAddressForCurrentConnection", null);
+
+        invokeMethod("persistLastKnownIpAddress", new Class<?>[0]);
+
+        verifyNoMoreInteractions(callback);
+    }
+
+    @Test
+    void preservesCachedIpAddressWhenDeviceInfoUpdatesProperties() throws Exception {
+        thing.setProperties(Map.of(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS, "127.0.0.1"));
+
+        invokeMethod("handleConnected", new Class<?>[] { com.google.protobuf.GeneratedMessage.class },
+                DeviceInfoResponse.newBuilder().setEsphomeVersion("2026.1.0").setMacAddress("AA:BB:CC:DD:EE:FF")
+                        .setModel("ESP32").setName("virtual").setManufacturer("Espressif")
+                        .setCompilationTime("2026-04-14T00:00:00Z").build());
+
+        verify(callback).thingUpdated(argThat(updatedThing -> "127.0.0.1"
+                .equals(updatedThing.getProperties().get(ESPHomeHandler.PROPERTY_LAST_KNOWN_IP_ADDRESS))
+                && "virtual".equals(updatedThing.getProperties().get("name"))));
+    }
+
+    private Object invokeMethod(String name, Class<?>[] parameterTypes, Object... args) throws Exception {
+        Method method = ESPHomeHandler.class.getDeclaredMethod(name, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(handler, args);
+    }
+
+    private Object invokeRecordAccessor(Object target, String accessorName) throws Exception {
+        Method accessor = target.getClass().getDeclaredMethod(accessorName);
+        accessor.setAccessible(true);
+        return accessor.invoke(target);
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = ESPHomeHandler.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(handler, value);
+    }
+}


### PR DESCRIPTION
And use it if the hostname cannot (currently) be resolved. This is useful in case the mDNS hostname can't currently be resolved, as is not unusual for devices that have somewhat flakey wifi connections, or other weirdness with OS/Java-level mDNS caches. This also means you can keep the default thing ID from discovered things in the inbox, without worrying about it overwriting explicitly specified IP addresses which have been put in to work around such name lookup issues.

Note that this is very similar to what the ESPHome dashboard does as well - I've noticed that it will say that it's using a cached or last known IP address sometimes when openHAB also can't connect, and it is able to connect.