### PR TITLE
Feature/firmware version and upgrade detection

### DIFF
--- a/src/main/java/no/seime/openhab/binding/esphome/internal/BindingConstants.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/BindingConstants.java
@@ -33,4 +33,7 @@ public class BindingConstants {
     public static final String CHANNEL_CONFIGURATION_ENTITY_KEY = "entity_key";
     public static final String CHANNEL_CONFIGURATION_ENTITY_TYPE = "entity_type";
     public static final String CHANNEL_CONFIGURATION_ENTITY_FIELD = "entity_field";
+
+    public static final String CHANNEL_LATEST_FIRMWARE_VERSION = "latestFirmwareVersion";
+    public static final String CHANNEL_FIRMWARE_UPDATE_AVAILABLE = "firmwareUpdateAvailable";
 }

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/ESPHomeVersionListener.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/ESPHomeVersionListener.java
@@ -1,0 +1,8 @@
+package no.seime.openhab.binding.esphome.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+@NonNullByDefault
+public interface ESPHomeVersionListener {
+    void onVersionUpdate(String version);
+}

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/ESPHomeVersionService.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/ESPHomeVersionService.java
@@ -1,0 +1,168 @@
+package no.seime.openhab.binding.esphome.internal;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.openhab.core.library.CoreItemFactory;
+import org.openhab.core.thing.Channel;
+import org.openhab.core.thing.ChannelUID;
+import org.openhab.core.thing.ThingUID;
+import org.openhab.core.thing.binding.builder.ChannelBuilder;
+import org.openhab.core.thing.type.AutoUpdatePolicy;
+import org.openhab.core.thing.type.ChannelType;
+import org.openhab.core.thing.type.ChannelTypeBuilder;
+import org.openhab.core.thing.type.ChannelTypeUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service that fetches the latest ESPHome version from the official release page on GitHub.
+ *
+ * @author Arne Seime - Initial contribution
+ */
+@NonNullByDefault
+public class ESPHomeVersionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ESPHomeVersionService.class);
+
+    private static final String CHANGELOG_URL = "https://github.com/esphome/esphome/releases/latest";
+
+    private @Nullable String latestVersion;
+
+    private final ScheduledExecutorService scheduler;
+
+    private @Nullable ScheduledFuture<?> scheduledFuture;
+
+    private final List<ESPHomeVersionListener> listeners = new CopyOnWriteArrayList<>();
+
+    public ESPHomeVersionService(ScheduledExecutorService scheduler) {
+        this.scheduler = scheduler;
+    }
+
+    public void start() {
+        scheduledFuture = scheduler.scheduleWithFixedDelay(this::fetchVersion, 0, 24, TimeUnit.HOURS);
+    }
+
+    public void stop() {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+        }
+    }
+
+    public void addListener(ESPHomeVersionListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(ESPHomeVersionListener listener) {
+        listeners.remove(listener);
+    }
+
+    void fetchVersion() {
+        try {
+            HttpURLConnection conn = (HttpURLConnection) new URL(CHANGELOG_URL).openConnection();
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(10000);
+            conn.setInstanceFollowRedirects(false);
+            int responseCode = conn.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_MOVED_TEMP || responseCode == HttpURLConnection.HTTP_MOVED_PERM
+                    || responseCode == 307 || responseCode == 308) {
+                String location = conn.getHeaderField("Location");
+                if (location != null) {
+                    String version = location.substring(location.lastIndexOf("/") + 1);
+                    if (version.startsWith("v")) {
+                        version = version.substring(1);
+                    }
+                    String versionToNotify = version;
+                    latestVersion = versionToNotify;
+                    LOGGER.info("Latest ESPHome version: {}", latestVersion);
+                    listeners.forEach(listener -> listener.onVersionUpdate(versionToNotify));
+                } else {
+                    LOGGER.warn("Redirected but no Location header found from {}", CHANGELOG_URL);
+                }
+            } else if (responseCode == HttpURLConnection.HTTP_OK) {
+                // In case it doesn't redirect but stays at the same URL (unlikely for /latest)
+                String url = conn.getURL().toString();
+                String version = url.substring(url.lastIndexOf("/") + 1);
+                String versionToNotify = version;
+                latestVersion = versionToNotify;
+                LOGGER.info("Latest ESPHome version: {}", latestVersion);
+                listeners.forEach(listener -> listener.onVersionUpdate(versionToNotify));
+            } else {
+                LOGGER.warn("Error fetching ESPHome version: HTTP {}", responseCode);
+            }
+            conn.disconnect();
+        } catch (IOException e) {
+            LOGGER.warn("Error fetching latest ESPHome version: {}", e.getMessage());
+        }
+    }
+
+    public @Nullable String getLatestVersion() {
+        return latestVersion;
+    }
+
+    public static boolean isVersionNewer(String latestVersion, String currentVersion, String logPrefix) {
+        try {
+            String[] latestParts = latestVersion.split("\\.");
+            String[] currentParts = currentVersion.split("\\.");
+            int length = Math.max(latestParts.length, currentParts.length);
+            for (int i = 0; i < length; i++) {
+                int latestPart = i < latestParts.length ? Integer.parseInt(latestParts[i].replaceAll("[^0-9]", "")) : 0;
+                int currentPart = i < currentParts.length ? Integer.parseInt(currentParts[i].replaceAll("[^0-9]", ""))
+                        : 0;
+                if (latestPart > currentPart) {
+                    return true;
+                } else if (latestPart < currentPart) {
+                    return false;
+                }
+            }
+        } catch (NumberFormatException e) {
+            LOGGER.debug("[{}] Could not parse version strings for comparison: {} and {}", logPrefix, latestVersion,
+                    currentVersion);
+        }
+        return false;
+    }
+
+    public ChannelType createLatestFirmwareVersionChannelType(ThingUID thingUID) {
+        return ChannelTypeBuilder
+                .state(new ChannelTypeUID(BindingConstants.BINDING_ID,
+                        thingUID.getId() + "_" + BindingConstants.CHANNEL_LATEST_FIRMWARE_VERSION),
+                        "Latest Firmware Version", CoreItemFactory.STRING)
+                .isAdvanced(true).withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+    }
+
+    public ChannelType createFirmwareUpdateAvailableChannelType(ThingUID thingUID) {
+        return ChannelTypeBuilder
+                .state(new ChannelTypeUID(BindingConstants.BINDING_ID,
+                        thingUID.getId() + "_" + BindingConstants.CHANNEL_FIRMWARE_UPDATE_AVAILABLE),
+                        "Firmware Update Available", CoreItemFactory.CONTACT)
+                .isAdvanced(true).withAutoUpdatePolicy(AutoUpdatePolicy.VETO).build();
+    }
+
+    public Channel createLatestFirmwareVersionChannel(ThingUID thingUID, ChannelTypeUID channelTypeUID) {
+        return ChannelBuilder
+                .create(new ChannelUID(thingUID, BindingConstants.CHANNEL_LATEST_FIRMWARE_VERSION),
+                        CoreItemFactory.STRING)
+                .withLabel("Latest Firmware Version")
+                .withDescription(
+                        "Latest version of ESPHome firmware fetched from https://github.com/esphome/esphome/releases/latest")
+                .withType(channelTypeUID).build();
+    }
+
+    public Channel createFirmwareUpdateAvailableChannel(ThingUID thingUID, ChannelTypeUID channelTypeUID) {
+        return ChannelBuilder
+                .create(new ChannelUID(thingUID, BindingConstants.CHANNEL_FIRMWARE_UPDATE_AVAILABLE),
+                        CoreItemFactory.CONTACT)
+                .withLabel("Firmware Update Available")
+                .withDescription(
+                        "OPEN if there is a newer version of ESPHome firmware available. This does only check your device version against the latest version published on GitHub, not against the version installed on your computer. Note that even if there is a new version on GitHub, it might not have been released for your favourite package manager.")
+                .withType(channelTypeUID).build();
+    }
+}

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -326,6 +326,13 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             }
 
             if (command == RefreshType.REFRESH) {
+                if (channelUID.getId().equals(BindingConstants.CHANNEL_LATEST_FIRMWARE_VERSION)
+                        || channelUID.getId().equals(BindingConstants.CHANNEL_FIRMWARE_UPDATE_AVAILABLE)) {
+                    updateVersionChannels(thing.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION),
+                            versionService.getLatestVersion());
+                    return;
+                }
+
                 try {
                     frameHelper.send(SubscribeStatesRequest.getDefaultInstance());
                 } catch (ProtocolAPIError e) {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandler.java
@@ -17,6 +17,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Instant;
 import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -26,6 +27,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.events.AbstractEvent;
 import org.openhab.core.events.EventPublisher;
+import org.openhab.core.library.types.OpenClosedType;
+import org.openhab.core.library.types.StringType;
 import org.openhab.core.thing.*;
 import org.openhab.core.thing.binding.BaseThingHandler;
 import org.openhab.core.thing.binding.ThingActions;
@@ -60,7 +63,7 @@ import no.seime.openhab.binding.esphome.internal.message.statesubscription.Event
  * @author Arne Seime - Initial contribution
  */
 @NonNullByDefault
-public class ESPHomeHandler extends BaseThingHandler implements CommunicationListener {
+public class ESPHomeHandler extends BaseThingHandler implements CommunicationListener, ESPHomeVersionListener {
 
     private static final int API_VERSION_MAJOR = 1;
     private static final int API_VERSION_MINOR = 14;
@@ -76,7 +79,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     private final ESPStateDescriptionProvider stateDescriptionProvider;
     private final Map<String, AbstractMessageHandler<? extends GeneratedMessage, ? extends GeneratedMessage>> commandTypeToHandlerMap = new HashMap<>();
     private final Map<Class<? extends GeneratedMessage>, AbstractMessageHandler<? extends GeneratedMessage, ? extends GeneratedMessage>> classToHandlerMap = new HashMap<>();
-    private final List<Channel> dynamicChannels = new ArrayList<>();
+    private final List<Channel> dynamicChannels = new CopyOnWriteArrayList<>();
     private final ESPHomeEventSubscriber eventSubscriber;
     private final MonitoredScheduledThreadPoolExecutor executorService;
     private final KeySequentialExecutor packetProcessor;
@@ -84,6 +87,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     @Nullable
     private final String defaultEncryptionKey;
     private final BundleContext bundleContext;
+    private final ESPHomeVersionService versionService;
     private @Nullable ESPHomeConfiguration config;
     private @Nullable EncryptedFrameHelper frameHelper;
     @Nullable
@@ -116,7 +120,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             ESPChannelTypeProvider dynamicChannelTypeProvider, ESPStateDescriptionProvider stateDescriptionProvider,
             ESPHomeEventSubscriber eventSubscriber, MonitoredScheduledThreadPoolExecutor executorService,
             KeySequentialExecutor packetProcessor, EventPublisher eventPublisher, @Nullable String defaultEncryptionKey,
-            BundleContext bundleContext) {
+            BundleContext bundleContext, ESPHomeVersionService versionService) {
         super(thing);
         this.connectionSelector = connectionSelector;
         this.dynamicChannelTypeProvider = dynamicChannelTypeProvider;
@@ -128,6 +132,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
         this.eventPublisher = eventPublisher;
         this.defaultEncryptionKey = defaultEncryptionKey;
         this.bundleContext = bundleContext;
+        this.versionService = versionService;
 
         // Register message handlers for each type of message pairs
         registerMessageHandler(EntityTypes.SELECT, new SelectMessageHandler(this), ListEntitiesSelectResponse.class,
@@ -189,6 +194,8 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             logPrefix = String.format("%s", config.logPrefix); // To avoid nullness warning
         }
 
+        versionService.addListener(this);
+
         exponentialBackoff = new ExponentialBackoff(config.reconnectInterval, config.maxReconnectInterval);
         if (config.hostname != null && !config.hostname.isEmpty()) {
             scheduleConnect(0);
@@ -201,6 +208,7 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
     public void dispose() {
         synchronized (connectionStateLock) {
             disposed = true;
+            versionService.removeListener(this);
             eventSubscriber.removeEventSubscriptions(this);
             stateDescriptionProvider.removeDescriptionsForThing(thing.getUID());
             setUndefToAllChannels();
@@ -481,12 +489,20 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
             } else {
                 props.remove("projectVersion");
             }
+
             updateThing(editThing().withProperties(props).build());
         } else if (message instanceof ListEntitiesDoneResponse) {
+
+            addFirmwareChannels();
+
             updateThing(editThing().withChannels(dynamicChannels).build());
             logger.debug("[{}] Device interrogation complete, done updating thing channels", logPrefix);
             interrogated = true;
             frameHelper.send(SubscribeStatesRequest.getDefaultInstance());
+
+            updateVersionChannels(thing.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION),
+                    versionService.getLatestVersion());
+
         } else if (message instanceof PingRequest) {
             logger.debug("[{}] Responding to ping request", logPrefix);
             frameHelper.send(PingResponse.getDefaultInstance());
@@ -570,6 +586,21 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
                         logPrefix, message.getClass().getName(), message);
             }
         }
+    }
+
+    private void addFirmwareChannels() {
+        ChannelType latestFirmwareVersionChannelType = versionService
+                .createLatestFirmwareVersionChannelType(thing.getUID());
+        ChannelType firmwareUpdateAvailableChannelType = versionService
+                .createFirmwareUpdateAvailableChannelType(thing.getUID());
+
+        addChannelType(latestFirmwareVersionChannelType);
+        addChannelType(firmwareUpdateAvailableChannelType);
+
+        dynamicChannels.add(0, versionService.createFirmwareUpdateAvailableChannel(thing.getUID(),
+                firmwareUpdateAvailableChannelType.getUID()));
+        dynamicChannels.add(0, versionService.createLatestFirmwareVersionChannel(thing.getUID(),
+                latestFirmwareVersionChannelType.getUID()));
     }
 
     public void sendBluetoothCommand(GeneratedMessage message) {
@@ -898,6 +929,25 @@ public class ESPHomeHandler extends BaseThingHandler implements CommunicationLis
 
     public @Nullable String getDeviceId() {
         return config != null ? config.deviceId : null;
+    }
+
+    @Override
+    public void onVersionUpdate(String version) {
+        String currentVersion = thing.getProperties().get(Thing.PROPERTY_FIRMWARE_VERSION);
+        updateVersionChannels(currentVersion, version);
+    }
+
+    private void updateVersionChannels(@Nullable String currentVersion, @Nullable String latestVersion) {
+        if (latestVersion != null) {
+            updateState(new ChannelUID(thing.getUID(), BindingConstants.CHANNEL_LATEST_FIRMWARE_VERSION),
+                    new StringType(latestVersion));
+            if (currentVersion != null) {
+                boolean updateAvailable = ESPHomeVersionService.isVersionNewer(latestVersion, currentVersion,
+                        logPrefix);
+                updateState(new ChannelUID(thing.getUID(), BindingConstants.CHANNEL_FIRMWARE_UPDATE_AVAILABLE),
+                        updateAvailable ? OpenClosedType.OPEN : OpenClosedType.CLOSED);
+            }
+        }
     }
 
     private enum ConnectionState {

--- a/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerFactory.java
+++ b/src/main/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerFactory.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import com.jano7.executor.KeySequentialExecutor;
 
 import no.seime.openhab.binding.esphome.internal.BindingConstants;
+import no.seime.openhab.binding.esphome.internal.ESPHomeVersionService;
 import no.seime.openhab.binding.esphome.internal.bluetooth.ESPHomeBluetoothProxyHandler;
 import no.seime.openhab.binding.esphome.internal.comm.ConnectionSelector;
 import no.seime.openhab.binding.esphome.internal.message.statesubscription.ESPHomeEventSubscriber;
@@ -74,6 +75,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
     private final MonitoredScheduledThreadPoolExecutor scheduler;
     private final KeySequentialExecutor packetExecutor;
     private final ConnectionSelector connectionSelector;
+    private final ESPHomeVersionService versionService;
 
     private final Map<ThingUID, ESPHomeHandler> esphomeHandlers = new ConcurrentHashMap<>();
 
@@ -100,6 +102,8 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
         this.eventPublisher = eventPublisher;
 
         connectionSelector = new ConnectionSelector();
+
+        versionService = new ESPHomeVersionService(scheduler);
     }
 
     @Override
@@ -109,7 +113,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
         if (BindingConstants.THING_TYPE_DEVICE.equals(thingTypeUID)) {
             ESPHomeHandler handler = new ESPHomeHandler(thing, connectionSelector, dynamicChannelTypeProvider,
                     stateDescriptionProvider, eventSubscriber, scheduler, packetExecutor, eventPublisher,
-                    defaultEncryptionKey, getBundleContext());
+                    defaultEncryptionKey, getBundleContext(), versionService);
             esphomeHandlers.put(thing.getUID(), handler);
             return handler;
         } else if (BindingConstants.THING_TYPE_BLE_PROXY.equals(thingTypeUID)) {
@@ -126,6 +130,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
     protected void activate(ComponentContext componentContext) {
         super.activate(componentContext);
         connectionSelector.start();
+        versionService.start();
         Dictionary<String, Object> properties = componentContext.getProperties();
         defaultEncryptionKey = StringUtils.trimToNull((String) properties.get("defaultEncryptionKey"));
         if (defaultEncryptionKey != null) {
@@ -137,6 +142,7 @@ public class ESPHomeHandlerFactory extends BaseThingHandlerFactory {
     @Override
     protected void deactivate(ComponentContext componentContext) {
         connectionSelector.stop();
+        versionService.stop();
         scheduler.shutdown();
         try {
             scheduler.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS);

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/AbstractESPHomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/AbstractESPHomeDeviceTest.java
@@ -33,6 +33,7 @@ import com.jano7.executor.KeySequentialExecutor;
 import no.seime.openhab.binding.esphome.deviceutil.ESPHomeDeviceRunner;
 import no.seime.openhab.binding.esphome.internal.BindingConstants;
 import no.seime.openhab.binding.esphome.internal.ESPHomeConfiguration;
+import no.seime.openhab.binding.esphome.internal.ESPHomeVersionService;
 import no.seime.openhab.binding.esphome.internal.LogLevel;
 import no.seime.openhab.binding.esphome.internal.comm.ConnectionSelector;
 import no.seime.openhab.binding.esphome.internal.handler.ESPChannelTypeProvider;
@@ -89,8 +90,24 @@ public abstract class AbstractESPHomeDeviceTest {
         when(itemRegistry.getItems()).thenReturn(registryItems);
         eventSubscriber = new ESPHomeEventSubscriber(thingRegistry, itemRegistry);
 
+        ESPHomeVersionService versionService = Mockito.mock(ESPHomeVersionService.class);
+        when(versionService.getLatestVersion()).thenReturn("2024.3.0");
+        when(versionService.createLatestFirmwareVersionChannelType(Mockito.any()))
+                .thenAnswer(invocation -> new ESPHomeVersionService(executor)
+                        .createLatestFirmwareVersionChannelType(invocation.getArgument(0)));
+        when(versionService.createFirmwareUpdateAvailableChannelType(Mockito.any()))
+                .thenAnswer(invocation -> new ESPHomeVersionService(executor)
+                        .createFirmwareUpdateAvailableChannelType(invocation.getArgument(0)));
+        when(versionService.createLatestFirmwareVersionChannel(Mockito.any(), Mockito.any()))
+                .thenAnswer(invocation -> new ESPHomeVersionService(executor)
+                        .createLatestFirmwareVersionChannel(invocation.getArgument(0), invocation.getArgument(1)));
+        when(versionService.createFirmwareUpdateAvailableChannel(Mockito.any(), Mockito.any()))
+                .thenAnswer(invocation -> new ESPHomeVersionService(executor)
+                        .createFirmwareUpdateAvailableChannel(invocation.getArgument(0), invocation.getArgument(1)));
+
         thingHandler = new ESPHomeHandler(thing, selector, channelTypeProvider, stateDescriptionProvider,
-                eventSubscriber, executor, new KeySequentialExecutor(executor), eventPublisher, null, bundleContext);
+                eventSubscriber, executor, new KeySequentialExecutor(executor), eventPublisher, null, bundleContext,
+                versionService);
         thingHandlerCallback = Mockito.mock(ThingHandlerCallback.class);
         thingHandler.setCallback(thingHandlerCallback);
 

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/CoverEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/CoverEsphomeDeviceTest.java
@@ -35,7 +35,7 @@ public class CoverEsphomeDeviceTest extends AbstractESPHomeDeviceTest {
         // Cover position
         // Cover state
 
-        assertEquals(4, thingHandler.getDynamicChannels().size());
+        assertEquals(6, thingHandler.getDynamicChannels().size());
 
         // Send using PercentType
         // Remove all other invocations for log readability

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/DuplicateEntityNamesEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/DuplicateEntityNamesEsphomeDeviceTest.java
@@ -22,9 +22,11 @@ public class DuplicateEntityNamesEsphomeDeviceTest extends AbstractESPHomeDevice
         await().until(() -> thingHandler.isInterrogated());
 
         // Only brightness channel should be created
-        assertEquals(2, thingHandler.getDynamicChannels().size());
-        assertEquals("climate", thingHandler.getDynamicChannels().get(0).getUID().getId());
-        assertEquals("climate_sensor", thingHandler.getDynamicChannels().get(1).getUID().getId());
+        assertEquals(4, thingHandler.getDynamicChannels().size());
+        assertEquals("latestFirmwareVersion", thingHandler.getDynamicChannels().get(0).getUID().getId());
+        assertEquals("firmwareUpdateAvailable", thingHandler.getDynamicChannels().get(1).getUID().getId());
+        assertEquals("climate", thingHandler.getDynamicChannels().get(2).getUID().getId());
+        assertEquals("climate_sensor", thingHandler.getDynamicChannels().get(3).getUID().getId());
 
         thingHandler.dispose();
     }

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/EmptyEntityNamesEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/EmptyEntityNamesEsphomeDeviceTest.java
@@ -22,10 +22,12 @@ public class EmptyEntityNamesEsphomeDeviceTest extends AbstractESPHomeDeviceTest
         await().until(() -> thingHandler.isInterrogated());
 
         // Only brightness channel should be created
-        assertEquals(3, thingHandler.getDynamicChannels().size());
-        assertEquals("None", thingHandler.getDynamicChannels().get(0).getLabel());
-        assertEquals("None", thingHandler.getDynamicChannels().get(1).getLabel());
-        assertEquals("Temperature", thingHandler.getDynamicChannels().get(2).getLabel());
+        assertEquals(5, thingHandler.getDynamicChannels().size());
+        assertEquals("Latest Firmware Version", thingHandler.getDynamicChannels().get(0).getLabel());
+        assertEquals("Firmware Update Available", thingHandler.getDynamicChannels().get(1).getLabel());
+        assertEquals("None", thingHandler.getDynamicChannels().get(2).getLabel());
+        assertEquals("None", thingHandler.getDynamicChannels().get(3).getLabel());
+        assertEquals("Temperature", thingHandler.getDynamicChannels().get(4).getLabel());
 
         thingHandler.dispose();
     }

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/EventDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/EventDeviceTest.java
@@ -24,8 +24,8 @@ public class EventDeviceTest extends AbstractESPHomeDeviceTest {
         thingHandler.initialize();
         await().until(() -> thingHandler.isInterrogated());
 
-        // 2 Events, 1 Switch
-        assertEquals(3, thingHandler.getDynamicChannels().size());
+        // 2 Events, 1 Switch + 2 for firmware
+        assertEquals(5, thingHandler.getDynamicChannels().size());
 
         ChannelUID switchChannelUID = new ChannelUID(thing.getUID(), "trigger_scene_dag");
         ChannelUID eventChannelUID = new ChannelUID(thing.getUID(), "scene_dag");

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/JeffJamesOpenhabStateToEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/JeffJamesOpenhabStateToEsphomeDeviceTest.java
@@ -30,7 +30,7 @@ public class JeffJamesOpenhabStateToEsphomeDeviceTest extends AbstractESPHomeDev
 
         thingHandler.initialize();
         await().until(() -> thingHandler.isInterrogated());
-        assertEquals(1, thingHandler.getDynamicChannels().size());
+        assertEquals(3, thingHandler.getDynamicChannels().size());
 
         // Verify that initial state is copied via the copy sensor and transferred back
         verify(thingHandlerCallback, timeout(2000))

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/LightEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/LightEsphomeDeviceTest.java
@@ -22,7 +22,7 @@ public class LightEsphomeDeviceTest extends AbstractESPHomeDeviceTest {
         await().until(() -> thingHandler.isInterrogated());
 
         // Only brightness channel should be created
-        assertEquals(1, thingHandler.getDynamicChannels().size());
+        assertEquals(3, thingHandler.getDynamicChannels().size());
 
         thingHandler.dispose();
     }

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/NumberDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/NumberDeviceTest.java
@@ -25,7 +25,7 @@ public class NumberDeviceTest extends AbstractESPHomeDeviceTest {
         thingHandler.initialize();
         await().until(() -> thingHandler.isInterrogated());
 
-        assertEquals(1, thingHandler.getDynamicChannels().size());
+        assertEquals(3, thingHandler.getDynamicChannels().size());
 
         verify(stateDescriptionProvider, timeout(2000)).setDescription(
                 eq(new ChannelUID(thing.getUID(), "water_total")),

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/OpenhabStateToEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/OpenhabStateToEsphomeDeviceTest.java
@@ -111,7 +111,7 @@ public class OpenhabStateToEsphomeDeviceTest extends AbstractESPHomeDeviceTest {
 
         thingHandler.initialize();
         await().until(() -> thingHandler.isInterrogated());
-        assertEquals(testParameters.size(), thingHandler.getDynamicChannels().size());
+        assertEquals(testParameters.size() + 2, thingHandler.getDynamicChannels().size()); // Firmware channels
 
         // Verify that initial state is copied via the copy sensor and transferred back
         for (Parameter parameter : testParameters) {

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/ThingActionEsphomeDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/ThingActionEsphomeDeviceTest.java
@@ -27,7 +27,7 @@ public class ThingActionEsphomeDeviceTest extends AbstractESPHomeDeviceTest {
         thingHandler.initialize();
         await().until(() -> thingHandler.isInterrogated());
 
-        assertEquals(0, thingHandler.getDynamicChannels().size());
+        assertEquals(2, thingHandler.getDynamicChannels().size());
 
         thingHandler.dispose();
     }

--- a/src/test/java/no/seime/openhab/binding/esphome/devicetest/ValveDeviceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/devicetest/ValveDeviceTest.java
@@ -25,8 +25,8 @@ public class ValveDeviceTest extends AbstractESPHomeDeviceTest {
 
         thingHandler.initialize();
         await().until(() -> thingHandler.isInterrogated());
-        // Valve 2, Switch 1
-        assertEquals(3, thingHandler.getDynamicChannels().size());
+        // Valve 2, Switch 1, Firmware version 1, Firmware update available 1 = 5
+        assertEquals(5, thingHandler.getDynamicChannels().size());
 
         // Valve will stay in IDLE all the time
         verify(thingHandlerCallback, timeout(2000)).stateUpdated(

--- a/src/test/java/no/seime/openhab/binding/esphome/internal/ESPHomeVersionServiceTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/internal/ESPHomeVersionServiceTest.java
@@ -1,0 +1,19 @@
+package no.seime.openhab.binding.esphome.internal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ESPHomeVersionServiceTest {
+
+    @Test
+    void testFetchVersion() {
+
+        ESPHomeVersionService versionService = new ESPHomeVersionService(Mockito.mock(ScheduledExecutorService.class));
+        versionService.fetchVersion();
+        assertNotNull(versionService.getLatestVersion());
+    }
+}

--- a/src/test/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerLastKnownIpAddressTest.java
+++ b/src/test/java/no/seime/openhab/binding/esphome/internal/handler/ESPHomeHandlerLastKnownIpAddressTest.java
@@ -1,12 +1,8 @@
 package no.seime.openhab.binding.esphome.internal.handler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -29,6 +25,7 @@ import com.jano7.executor.KeySequentialExecutor;
 
 import io.esphome.api.DeviceInfoResponse;
 import no.seime.openhab.binding.esphome.internal.BindingConstants;
+import no.seime.openhab.binding.esphome.internal.ESPHomeVersionService;
 import no.seime.openhab.binding.esphome.internal.comm.ConnectionSelector;
 import no.seime.openhab.binding.esphome.internal.comm.ProtocolAPIError;
 import no.seime.openhab.binding.esphome.internal.message.statesubscription.ESPHomeEventSubscriber;
@@ -61,7 +58,7 @@ class ESPHomeHandlerLastKnownIpAddressTest {
         packetProcessorExecutor = Executors.newSingleThreadExecutor();
         handler = new ESPHomeHandler(thing, new ConnectionSelector(), channelTypeProvider, stateDescriptionProvider,
                 eventSubscriber, executor, new KeySequentialExecutor(packetProcessorExecutor), eventPublisher, null,
-                bundleContext);
+                bundleContext, mock(ESPHomeVersionService.class));
         handler.setCallback(callback);
     }
 


### PR DESCRIPTION
Fetches latest esphome version from github and compares with version reported by device.

Adds 2 advanced channels:
1) latest version available
2) contact that is OPEN if a newer version for given devices is available